### PR TITLE
      - name: Extract Jira issue key from GitHub issue title         id: extract-key         run: |           ISSUE_TITLE="${{ github.event.issue.title }}"           JIRA_KEY=$(echo "$ISSUE_TITLE" | grep -oE '[A-Z]+-[0-9]+')           echo "JIRA_KEY=$JIRA_KEY" >> $GITHUB_ENV

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -47,7 +47,7 @@ jobs:
         id: create
         uses: atlassian/gajira-create@v3
         with:
-          project: SKP
+          project: SSN
           issuetype: Task
           summary: '${{ github.event.issue.title }}'
           description: '${{ steps.md2jira.outputs.output-text }}'


### PR DESCRIPTION
## 🔗 연관된 이슈

- #9 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- jira 연동 오류 수정