### PR TITLE
fix: Jira 연동 오류 수정 

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: SSN
-          issuetype: Task
+          issuetype: Sub-task
           summary: '${{ github.event.issue.title }}'
           description: '${{ steps.md2jira.outputs.output-text }}'
           fields: |


### PR DESCRIPTION
## 🔗 연관된 이슈

- #9

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- Jira 연동 오류 수정 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub 이슈가 생성될 때 Jira 이슈 유형이 "Task"에서 "Sub-task"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->