### PR TITLE
fix: 소셜 로그인 프론트 주소로 리다이렉트 

### DIFF
--- a/src/main/java/com/susanghan_guys/server/global/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/susanghan_guys/server/global/oauth2/handler/OAuth2SuccessHandler.java
@@ -41,6 +41,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         refreshTokenRepository.save(new RefreshToken(user.getId(), refreshToken));
 
+        // TODO: accessToken, refreshToken 보안 관련 수정
+
         String redirectUri = createRedirectUri(accessToken, refreshToken);
         response.sendRedirect(redirectUri);
     }

--- a/src/main/java/com/susanghan_guys/server/global/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/susanghan_guys/server/global/oauth2/handler/OAuth2SuccessHandler.java
@@ -36,21 +36,18 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
         User user = customUserDetails.getUser();
 
-        String provider = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
-
         String accessToken = jwtProvider.createAccessToken(user.getId());
         String refreshToken = jwtProvider.createRefreshToken(user.getId());
 
         refreshTokenRepository.save(new RefreshToken(user.getId(), refreshToken));
 
-        String redirectUri = createRedirectUri(provider, accessToken, refreshToken);
+        String redirectUri = createRedirectUri(accessToken, refreshToken);
         response.sendRedirect(redirectUri);
     }
 
-    private String createRedirectUri(String provider, String accessToken, String refreshToken) {
+    private String createRedirectUri(String accessToken, String refreshToken) {
         return UriComponentsBuilder
                 .fromUriString(redirectUri)
-                .queryParam("provider", provider)
                 .queryParam("accessToken", accessToken)
                 .queryParam("refreshToken", refreshToken)
                 .build()

--- a/src/main/java/com/susanghan_guys/server/global/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/susanghan_guys/server/global/oauth2/handler/OAuth2SuccessHandler.java
@@ -1,6 +1,5 @@
 package com.susanghan_guys.server.global.oauth2.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.susanghan_guys.server.global.jwt.JwtProvider;
 import com.susanghan_guys.server.global.oauth2.domain.RefreshToken;
 import com.susanghan_guys.server.global.oauth2.infrastructure.persistence.RefreshTokenRepository;
@@ -9,12 +8,14 @@ import com.susanghan_guys.server.user.domain.User;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -22,7 +23,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
-    private final ObjectMapper objectMapper;
+
+    @Value("${frontend.oauth2.redirect-uri}")
+    private String redirectUri;
 
     @Override
     public void onAuthenticationSuccess(
@@ -33,16 +36,24 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
         User user = customUserDetails.getUser();
 
+        String provider = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
+
         String accessToken = jwtProvider.createAccessToken(user.getId());
         String refreshToken = jwtProvider.createRefreshToken(user.getId());
 
         refreshTokenRepository.save(new RefreshToken(user.getId(), refreshToken));
 
-        Map<String, Object> tokens = Map.of(
-                "accessToken", accessToken,
-                "refreshToken", refreshToken
-        );
-        response.setContentType("application/json;charset=UTF-8");
-        objectMapper.writeValue(response.getWriter(), tokens);
+        String redirectUri = createRedirectUri(provider, accessToken, refreshToken);
+        response.sendRedirect(redirectUri);
+    }
+
+    private String createRedirectUri(String provider, String accessToken, String refreshToken) {
+        return UriComponentsBuilder
+                .fromUriString(redirectUri)
+                .queryParam("provider", provider)
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build()
+                .toString();
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- #36 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 소셜 로그인 시, 프론트 주소로 리다이렉트 되게 코드 추가

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/687cb7d1-3f97-4035-8b6f-cb9f4b538f0d)
## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 토큰 탈취 위험이 있어서 추후 수정이 필요할 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **New Features**
  * OAuth2 인증 성공 시, 액세스 토큰과 리프레시 토큰이 프론트엔드로 리디렉션되는 URL의 쿼리 파라미터로 전달됩니다.

* **변경 사항**
  * 토큰이 더 이상 JSON 형태로 응답 본문에 반환되지 않고, 리디렉션 방식으로 전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->