### PR TITLE
feat: 사용자 정보 조회 API

### DIFF
--- a/src/main/java/com/susanghan_guys/server/global/common/code/ErrorCode.java
+++ b/src/main/java/com/susanghan_guys/server/global/common/code/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode implements BaseCode {
 
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 401, "유효하지 않은 토큰입니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "존재하지 않는 리프레시 토큰입니다."),
+    TOKEN_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "토큰 파싱에 실패했습니다."),
+    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, 400, "유효하지 않은 인증 코드 입니다."),
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "존재하지 않는 사용자입니다."),
     REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, 400, "필수 약관에 동의하지 않았습니다."),

--- a/src/main/java/com/susanghan_guys/server/global/common/code/ErrorCode.java
+++ b/src/main/java/com/susanghan_guys/server/global/common/code/ErrorCode.java
@@ -11,7 +11,7 @@ public enum ErrorCode implements BaseCode {
     // 공통 에러
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 내부 오류가 발생했습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, 400, "잘못된 요청입니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,401,"인증이 필요합니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 401, "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, 403, "접근 권한이 없습니다."),
 
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 401, "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/susanghan_guys/server/global/common/code/SuccessCode.java
+++ b/src/main/java/com/susanghan_guys/server/global/common/code/SuccessCode.java
@@ -13,6 +13,7 @@ public enum SuccessCode implements BaseCode {
 
     // token
     REFRESH_TOKEN_UPDATE_SUCCESS(HttpStatus.OK, 200, "Refresh Token Update Success"),
+    EXCHANGE_TOKEN_SUCCESS(HttpStatus.OK, 200, "Exchange Token Success"),
 
     // user
     USER_LOGOUT_SUCCESS(HttpStatus.OK, 200, "User Logout Success"),

--- a/src/main/java/com/susanghan_guys/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/susanghan_guys/server/global/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
                                 "/webjars/**",
                                 "/global/health-check",
                                 "/login/oauth2/**",
-                                "/v1/auth/refresh-token"
+                                "/v1/auth/refresh-token",
+                                "/v1/auth/user-info"
                         ).permitAll()
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/susanghan_guys/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/susanghan_guys/server/global/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                                 "/global/health-check",
                                 "/login/oauth2/**",
                                 "/v1/auth/refresh-token",
-                                "/v1/auth/user-info"
+                                "/v1/auth/exchange"
                         ).permitAll()
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/susanghan_guys/server/global/oauth2/application/CustomOAuth2UserService.java
+++ b/src/main/java/com/susanghan_guys/server/global/oauth2/application/CustomOAuth2UserService.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Slf4j
 @Service
@@ -45,11 +47,14 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             throw new OAuth2AuthenticationException("소셜 로그인에 이메일 정보가 없습니다.");
         }
 
-        User user = userRepository.findByEmail(email)
-                .orElseGet(() -> {
-                    User newUser = UserMapper.toDomain(oAuth2UserInfo);
-                    return userRepository.save(newUser);
-                });
+        Optional<User> optionalUser = userRepository.findByEmail(email);
+        AtomicBoolean isSignUp = new AtomicBoolean(false);
+
+        User user = optionalUser.orElseGet(() -> {
+            isSignUp.set(true);
+            User newUser = UserMapper.toDomain(oAuth2UserInfo);
+            return userRepository.save(newUser);
+        });
 
         return new CustomUserDetails(user, attributes);
     }

--- a/src/main/java/com/susanghan_guys/server/global/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/susanghan_guys/server/global/oauth2/handler/OAuth2SuccessHandler.java
@@ -16,7 +16,6 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 

--- a/src/main/java/com/susanghan_guys/server/global/util/RedisUtil.java
+++ b/src/main/java/com/susanghan_guys/server/global/util/RedisUtil.java
@@ -1,0 +1,26 @@
+package com.susanghan_guys.server.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setValue(String key, Object value, Long expiredTime) {
+        redisTemplate.opsForValue().set(key, value, expiredTime, TimeUnit.MILLISECONDS);
+    }
+
+    public String getValue(String key) {
+        return (String) redisTemplate.opsForValue().get(key);
+    }
+
+    public void deleteValue(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/susanghan_guys/server/user/application/UserAuthService.java
+++ b/src/main/java/com/susanghan_guys/server/user/application/UserAuthService.java
@@ -12,7 +12,7 @@ import com.susanghan_guys.server.global.oauth2.infrastructure.persistence.Refres
 import com.susanghan_guys.server.global.util.RedisUtil;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.user.dto.response.RefreshTokenResponse;
-import com.susanghan_guys.server.user.dto.response.UserInfoResponse;
+import com.susanghan_guys.server.user.dto.response.ExchangeTokenResponse;
 import com.susanghan_guys.server.user.infrastructure.persistence.UserRepository;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +34,7 @@ public class UserAuthService {
     private final ObjectMapper objectMapper;
     private final RedisUtil redisUtil;
 
-    public UserInfoResponse getUserInfo(String code) throws JsonProcessingException {
+    public ExchangeTokenResponse exchangeToken(String code) throws JsonProcessingException {
         String key = "auth:" + code;
         String json = redisUtil.getValue(key);
 
@@ -51,7 +51,7 @@ public class UserAuthService {
 
         redisUtil.deleteValue(key);
 
-        return UserInfoResponse.of(accessToken, refreshToken, user, isSignUp);
+        return ExchangeTokenResponse.of(accessToken, refreshToken, user, isSignUp);
     }
 
     @Transactional

--- a/src/main/java/com/susanghan_guys/server/user/application/UserAuthService.java
+++ b/src/main/java/com/susanghan_guys/server/user/application/UserAuthService.java
@@ -1,13 +1,18 @@
 package com.susanghan_guys.server.user.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.susanghan_guys.server.global.common.code.ErrorCode;
 import com.susanghan_guys.server.global.exception.BusinessException;
 import com.susanghan_guys.server.global.jwt.JwtProvider;
 import com.susanghan_guys.server.global.oauth2.application.TokenBlackListService;
 import com.susanghan_guys.server.global.oauth2.domain.RefreshToken;
 import com.susanghan_guys.server.global.oauth2.infrastructure.persistence.RefreshTokenRepository;
+import com.susanghan_guys.server.global.util.RedisUtil;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.user.dto.response.RefreshTokenResponse;
+import com.susanghan_guys.server.user.dto.response.UserInfoResponse;
 import com.susanghan_guys.server.user.infrastructure.persistence.UserRepository;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
@@ -15,15 +20,39 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserAuthService {
 
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final TokenBlackListService tokenBlackListService;
+    private final ObjectMapper objectMapper;
+    private final RedisUtil redisUtil;
+
+    public UserInfoResponse getUserInfo(String code) throws JsonProcessingException {
+        String key = "auth:" + code;
+        String json = redisUtil.getValue(key);
+
+        Map<String, String> data = objectMapper.readValue(json, new TypeReference<>() {});
+        String accessToken = data.get("accessToken");
+        String refreshToken = data.get("refreshToken");
+        boolean isSignUp = Boolean.parseBoolean(data.get("isSignUp"));
+
+        Claims claims = jwtProvider.getClaims(accessToken);
+        String userId = claims.getSubject();
+
+        User user = userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        redisUtil.deleteValue(key);
+
+        return UserInfoResponse.of(accessToken, refreshToken, user, isSignUp);
+    }
 
     @Transactional
     public void logout(String accessToken) {

--- a/src/main/java/com/susanghan_guys/server/user/application/UserService.java
+++ b/src/main/java/com/susanghan_guys/server/user/application/UserService.java
@@ -8,6 +8,7 @@ import com.susanghan_guys.server.user.domain.type.Purpose;
 import com.susanghan_guys.server.user.dto.request.UserOnboardingRequest;
 import com.susanghan_guys.server.user.dto.request.UserTermsRequest;
 import com.susanghan_guys.server.user.domain.User;
+import com.susanghan_guys.server.user.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,14 +19,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final CurrentUserProvider currentUserProvider;
+    private final UserValidator userValidator;
 
     @Transactional
     public void saveUserAgreement(UserTermsRequest request) {
         User user = currentUserProvider.getCurrentUser();
 
-        if (!request.isServiceAgreement() || !request.isUserInfoAgreement()) {
-            throw new BusinessException(ErrorCode.REQUIRED_TERMS_NOT_AGREED);
-        }
+        userValidator.validateUserAgreement(request);
+
         user.updateUserAgreement(true, true, request.isMarketingAgreement());
     }
 
@@ -33,7 +34,7 @@ public class UserService {
     public void saveUserOnboarding(UserOnboardingRequest request) {
         User user = currentUserProvider.getCurrentUser();
 
-        validateUserOnboarding(request);
+        userValidator.validateUserOnboarding(request);
 
         user.updateUserOnboarding(
                 true,
@@ -43,19 +44,5 @@ public class UserService {
                 request.channel(),
                 request.channelEtc()
         );
-    }
-
-    private void validateUserOnboarding(UserOnboardingRequest request) {
-        if (Channel.ETC.equals(request.channel())) {
-            if (request.channelEtc() == null || request.channelEtc().isBlank()) {
-                throw new BusinessException(ErrorCode.ETC_DETAIL_REQUIRED);
-            }
-        }
-
-        if (Purpose.ETC.equals(request.purpose())) {
-            if (request.purposeEtc() == null || request.purposeEtc().isBlank()) {
-                throw new BusinessException(ErrorCode.ETC_DETAIL_REQUIRED);
-            }
-        }
     }
 }

--- a/src/main/java/com/susanghan_guys/server/user/application/UserService.java
+++ b/src/main/java/com/susanghan_guys/server/user/application/UserService.java
@@ -36,6 +36,7 @@ public class UserService {
         validateUserOnboarding(request);
 
         user.updateUserOnboarding(
+                true,
                 request.role(),
                 request.purpose(),
                 request.purposeEtc(),

--- a/src/main/java/com/susanghan_guys/server/user/domain/User.java
+++ b/src/main/java/com/susanghan_guys/server/user/domain/User.java
@@ -43,6 +43,9 @@ public class User extends BaseEntity {
     @Column(name = "is_marketing_agreement")
     private Boolean isMarketingAgreement;
 
+    @Column(name = "is_onboarded")
+    private boolean isOnboarded = false;
+
     @ElementCollection(fetch = FetchType.LAZY)
     @Enumerated(EnumType.STRING)
     @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
@@ -78,6 +81,7 @@ public class User extends BaseEntity {
             Boolean isServiceAgreement,
             Boolean isUserInfoAgreement,
             Boolean isMarketingAgreement,
+            boolean isOnboarded,
             List<Role> roles,
             Channel channel,
             String channelEtc,
@@ -91,6 +95,7 @@ public class User extends BaseEntity {
         this.isServiceAgreement = isServiceAgreement;
         this.isUserInfoAgreement = isUserInfoAgreement;
         this.isMarketingAgreement = isMarketingAgreement;
+        this.isOnboarded = isOnboarded;
         this.roles = roles;
         this.channel = channel;
         this.channelEtc = channelEtc;
@@ -115,12 +120,14 @@ public class User extends BaseEntity {
     }
 
     public void updateUserOnboarding(
+            Boolean isOnboarded,
             List<Role> roles,
             Purpose purpose,
             String purposeEtc,
             Channel channel,
             String channelEtc
     ) {
+        this.isOnboarded = isOnboarded;
         this.roles = roles;
         this.purpose = purpose;
         this.purposeEtc = purposeEtc;

--- a/src/main/java/com/susanghan_guys/server/user/dto/response/ExchangeTokenResponse.java
+++ b/src/main/java/com/susanghan_guys/server/user/dto/response/ExchangeTokenResponse.java
@@ -4,7 +4,7 @@ import com.susanghan_guys.server.user.domain.User;
 import lombok.Builder;
 
 @Builder
-public record UserInfoResponse(
+public record ExchangeTokenResponse(
         String accessToken,
         String refreshToken,
         Long userId,
@@ -13,13 +13,13 @@ public record UserInfoResponse(
         boolean isSignUp,
         boolean isOnboarded
 ) {
-    public static UserInfoResponse of(
+    public static ExchangeTokenResponse of(
             String accessToken,
             String refreshToken,
             User user,
             boolean isSignUp
     ) {
-        return UserInfoResponse.builder()
+        return ExchangeTokenResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .userId(user.getId())

--- a/src/main/java/com/susanghan_guys/server/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/susanghan_guys/server/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,31 @@
+package com.susanghan_guys.server.user.dto.response;
+
+import com.susanghan_guys.server.user.domain.User;
+import lombok.Builder;
+
+@Builder
+public record UserInfoResponse(
+        String accessToken,
+        String refreshToken,
+        Long userId,
+        String name,
+        String email,
+        boolean isSignUp,
+        boolean isOnboarded
+) {
+    public static UserInfoResponse of(
+            String accessToken,
+            String refreshToken,
+            User user,
+            boolean isSignUp
+    ) {
+        return UserInfoResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .userId(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .isSignUp(isSignUp)
+                .build();
+    }
+}

--- a/src/main/java/com/susanghan_guys/server/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/susanghan_guys/server/user/dto/response/UserInfoResponse.java
@@ -26,6 +26,7 @@ public record UserInfoResponse(
                 .name(user.getName())
                 .email(user.getEmail())
                 .isSignUp(isSignUp)
+                .isOnboarded(user.isOnboarded())
                 .build();
     }
 }

--- a/src/main/java/com/susanghan_guys/server/user/presentation/UserAuthController.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/UserAuthController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import static com.susanghan_guys.server.global.common.code.SuccessCode.EXCHANGE_TOKEN_SUCCESS;
 import static com.susanghan_guys.server.global.common.code.SuccessCode.USER_LOGOUT_SUCCESS;
 import static com.susanghan_guys.server.global.common.code.SuccessCode.REFRESH_TOKEN_UPDATE_SUCCESS;
 
@@ -27,7 +28,7 @@ public class UserAuthController implements UserAuthSwagger {
     @Override
     @GetMapping("/exchange")
     public CommonResponse<ExchangeTokenResponse> exchangeToken(@RequestParam String code) throws JsonProcessingException {
-        return CommonResponse.success(USER_LOGOUT_SUCCESS, userAuthService.exchangeToken(code));
+        return CommonResponse.success(EXCHANGE_TOKEN_SUCCESS, userAuthService.exchangeToken(code));
     }
 
     @Override

--- a/src/main/java/com/susanghan_guys/server/user/presentation/UserAuthController.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/UserAuthController.java
@@ -6,7 +6,7 @@ import com.susanghan_guys.server.global.jwt.JwtProvider;
 import com.susanghan_guys.server.user.application.UserAuthService;
 import com.susanghan_guys.server.user.dto.request.RefreshTokenRequest;
 import com.susanghan_guys.server.user.dto.response.RefreshTokenResponse;
-import com.susanghan_guys.server.user.dto.response.UserInfoResponse;
+import com.susanghan_guys.server.user.dto.response.ExchangeTokenResponse;
 import com.susanghan_guys.server.user.presentation.swagger.UserAuthSwagger;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -25,9 +25,9 @@ public class UserAuthController implements UserAuthSwagger {
     private final UserAuthService userAuthService;
 
     // @Override
-    @GetMapping("/user-info")
-    public CommonResponse<UserInfoResponse> getUserInfo(@RequestParam String code) throws JsonProcessingException {
-        return CommonResponse.success(USER_LOGOUT_SUCCESS, userAuthService.getUserInfo(code));
+    @GetMapping("/exchange")
+    public CommonResponse<ExchangeTokenResponse> exchangeToken(@RequestParam String code) throws JsonProcessingException {
+        return CommonResponse.success(USER_LOGOUT_SUCCESS, userAuthService.exchangeToken(code));
     }
 
     @Override

--- a/src/main/java/com/susanghan_guys/server/user/presentation/UserAuthController.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/UserAuthController.java
@@ -40,7 +40,6 @@ public class UserAuthController implements UserAuthSwagger {
     @Override
     @PostMapping("/refresh-token")
     public CommonResponse<RefreshTokenResponse> updateRefreshToken(@RequestBody @Valid RefreshTokenRequest request) {
-        RefreshTokenResponse refreshTokenResponse = userAuthService.refreshTokenResponse(request.refreshToken());
-        return CommonResponse.success(REFRESH_TOKEN_UPDATE_SUCCESS, refreshTokenResponse);
+        return CommonResponse.success(REFRESH_TOKEN_UPDATE_SUCCESS, userAuthService.refreshTokenResponse(request.refreshToken()));
     }
 }

--- a/src/main/java/com/susanghan_guys/server/user/presentation/UserAuthController.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/UserAuthController.java
@@ -1,18 +1,17 @@
 package com.susanghan_guys.server.user.presentation;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.susanghan_guys.server.global.common.CommonResponse;
 import com.susanghan_guys.server.global.jwt.JwtProvider;
 import com.susanghan_guys.server.user.application.UserAuthService;
 import com.susanghan_guys.server.user.dto.request.RefreshTokenRequest;
 import com.susanghan_guys.server.user.dto.response.RefreshTokenResponse;
+import com.susanghan_guys.server.user.dto.response.UserInfoResponse;
 import com.susanghan_guys.server.user.presentation.swagger.UserAuthSwagger;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.susanghan_guys.server.global.common.code.SuccessCode.USER_LOGOUT_SUCCESS;
 import static com.susanghan_guys.server.global.common.code.SuccessCode.REFRESH_TOKEN_UPDATE_SUCCESS;
@@ -24,6 +23,12 @@ public class UserAuthController implements UserAuthSwagger {
 
     private final JwtProvider jwtProvider;
     private final UserAuthService userAuthService;
+
+    // @Override
+    @GetMapping("/user-info")
+    public CommonResponse<UserInfoResponse> getUserInfo(@RequestParam String code) throws JsonProcessingException {
+        return CommonResponse.success(USER_LOGOUT_SUCCESS, userAuthService.getUserInfo(code));
+    }
 
     @Override
     @PostMapping("/logout")

--- a/src/main/java/com/susanghan_guys/server/user/presentation/UserAuthController.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/UserAuthController.java
@@ -24,7 +24,7 @@ public class UserAuthController implements UserAuthSwagger {
     private final JwtProvider jwtProvider;
     private final UserAuthService userAuthService;
 
-    // @Override
+    @Override
     @GetMapping("/exchange")
     public CommonResponse<ExchangeTokenResponse> exchangeToken(@RequestParam String code) throws JsonProcessingException {
         return CommonResponse.success(USER_LOGOUT_SUCCESS, userAuthService.exchangeToken(code));

--- a/src/main/java/com/susanghan_guys/server/user/presentation/UserAuthController.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/UserAuthController.java
@@ -27,7 +27,7 @@ public class UserAuthController implements UserAuthSwagger {
 
     @Override
     @GetMapping("/exchange")
-    public CommonResponse<ExchangeTokenResponse> exchangeToken(@RequestParam String code) throws JsonProcessingException {
+    public CommonResponse<ExchangeTokenResponse> exchangeToken(@RequestParam String code) {
         return CommonResponse.success(EXCHANGE_TOKEN_SUCCESS, userAuthService.exchangeToken(code));
     }
 

--- a/src/main/java/com/susanghan_guys/server/user/presentation/swagger/UserAuthSwagger.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/swagger/UserAuthSwagger.java
@@ -1,7 +1,9 @@
 package com.susanghan_guys.server.user.presentation.swagger;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.susanghan_guys.server.global.common.CommonResponse;
 import com.susanghan_guys.server.user.dto.request.RefreshTokenRequest;
+import com.susanghan_guys.server.user.dto.response.ExchangeTokenResponse;
 import com.susanghan_guys.server.user.dto.response.RefreshTokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -10,9 +12,24 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "[사용자 인증]", description = "사용자 로그아웃, 토큰 재발급 관련 API")
 public interface UserAuthSwagger {
+    @Operation(
+            summary = "사용자 토큰 및 정보 조회 API",
+            description = "발급된 임시 코드를 통해 사용자의 accessToken, refreshToken 및 정보를 반환합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 토큰 및 정보 조회가 성공적으로 실행되었습니다."
+            )
+    })
+    CommonResponse<ExchangeTokenResponse> exchangeToken(
+            @RequestParam String code
+    ) throws JsonProcessingException;
+
     @Operation(
             summary = "사용자 로그아웃 API",
             description = "사용자 로그아웃을 진행합니다."

--- a/src/main/java/com/susanghan_guys/server/user/presentation/swagger/UserAuthSwagger.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/swagger/UserAuthSwagger.java
@@ -28,7 +28,7 @@ public interface UserAuthSwagger {
     })
     CommonResponse<ExchangeTokenResponse> exchangeToken(
             @RequestParam String code
-    ) throws JsonProcessingException;
+    );
 
     @Operation(
             summary = "사용자 로그아웃 API",

--- a/src/main/java/com/susanghan_guys/server/user/validator/UserValidator.java
+++ b/src/main/java/com/susanghan_guys/server/user/validator/UserValidator.java
@@ -1,0 +1,33 @@
+package com.susanghan_guys.server.user.validator;
+
+import com.susanghan_guys.server.global.common.code.ErrorCode;
+import com.susanghan_guys.server.global.exception.BusinessException;
+import com.susanghan_guys.server.user.domain.type.Channel;
+import com.susanghan_guys.server.user.domain.type.Purpose;
+import com.susanghan_guys.server.user.dto.request.UserOnboardingRequest;
+import com.susanghan_guys.server.user.dto.request.UserTermsRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserValidator {
+
+    public void validateUserAgreement(UserTermsRequest request) {
+        if (!request.isServiceAgreement() || !request.isUserInfoAgreement()) {
+            throw new BusinessException(ErrorCode.REQUIRED_TERMS_NOT_AGREED);
+        }
+    }
+
+    public void validateUserOnboarding(UserOnboardingRequest request) {
+        if (Channel.ETC.equals(request.channel())) {
+            if (request.channelEtc() == null || request.channelEtc().isBlank()) {
+                throw new BusinessException(ErrorCode.ETC_DETAIL_REQUIRED);
+            }
+        }
+
+        if (Purpose.ETC.equals(request.purpose())) {
+            if (request.purposeEtc() == null || request.purposeEtc().isBlank()) {
+                throw new BusinessException(ErrorCode.ETC_DETAIL_REQUIRED);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

- #44 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 쿼리에 담아서 보내던 token 임시 코드로 수정
- 임시 코드로 토큰 및 사용자 정보 조회 가능

## 📸 스크린샷
- 리다이렉트 시, 쿼리에 임시 코드
<img width="1171" height="982" alt="image" src="https://github.com/user-attachments/assets/8d385ef1-5130-4985-926d-349ccf5d6e0c" />

- 발급된 코드로 토큰 및 사용자 정보 조회
<img width="586" height="492" alt="image" src="https://github.com/user-attachments/assets/1c3b5a13-6dd5-4af5-96dc-ecb42b1655e7" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 소셜 로그인 후 임시 코드로 토큰을 교환하는 API가 추가되었습니다. (GET /v1/auth/exchange)
  * 토큰 교환 시 사용자 정보(가입 여부, 온보딩 여부 등)도 함께 반환됩니다.
  * 사용자 온보딩 및 약관 동의에 대한 검증 로직이 별도 컴포넌트로 분리되어 강화되었습니다.
  * 인증 관련 공개 엔드포인트가 추가되어 인증 없이 접근 가능한 경로가 확장되었습니다.

* **기타**
  * 유저 엔티티에 온보딩 여부 필드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->