### PR TITLE
feat: 사용자 탈퇴 API

### DIFF
--- a/src/main/java/com/susanghan_guys/server/global/common/CommonResponse.java
+++ b/src/main/java/com/susanghan_guys/server/global/common/CommonResponse.java
@@ -1,7 +1,7 @@
 package com.susanghan_guys.server.global.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.susanghan_guys.server.global.common.code.ErrorCode;
+import com.susanghan_guys.server.global.common.code.BaseCode;
 import com.susanghan_guys.server.global.common.code.SuccessCode;
 
 public record CommonResponse<T>(
@@ -19,11 +19,11 @@ public record CommonResponse<T>(
         return new CommonResponse<>(true, code.getStatus(), code.getMessage(), "");
     }
 
-    public static <T> CommonResponse<T> failure(ErrorCode errorCode, T data) {
+    public static <T> CommonResponse<T> failure(BaseCode errorCode, T data) {
         return new CommonResponse<>(false, errorCode.getStatus(), errorCode.getMessage(), data);
     }
 
-    public static CommonResponse<Void> failure(ErrorCode errorCode) {
+    public static CommonResponse<Void> failure(BaseCode errorCode) {
         return new CommonResponse<>(false, errorCode.getStatus(), errorCode.getMessage(), null);
     }
 }

--- a/src/main/java/com/susanghan_guys/server/global/common/code/BaseCode.java
+++ b/src/main/java/com/susanghan_guys/server/global/common/code/BaseCode.java
@@ -1,6 +1,9 @@
 package com.susanghan_guys.server.global.common.code;
 
+import org.springframework.http.HttpStatus;
+
 public interface BaseCode {
+    HttpStatus getHttpStatus();
     int getStatus();
     String getMessage();
 }

--- a/src/main/java/com/susanghan_guys/server/global/common/code/SuccessCode.java
+++ b/src/main/java/com/susanghan_guys/server/global/common/code/SuccessCode.java
@@ -21,6 +21,7 @@ public enum SuccessCode implements BaseCode {
     USER_ONBOARDING_SUCCESS(HttpStatus.OK, 200, "User Onboarding Success"),
     USER_INFO_SUCCESS(HttpStatus.OK, 200, "User Info Success"),
     USER_INFO_UPDATE_SUCCESS(HttpStatus.OK, 200, "User Info Update Success"),
+    USER_WITHDRAWAL_SUCCESS(HttpStatus.OK, 200, "User Withdrawal Success"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/susanghan_guys/server/global/exception/BusinessException.java
+++ b/src/main/java/com/susanghan_guys/server/global/exception/BusinessException.java
@@ -1,14 +1,14 @@
 package com.susanghan_guys.server.global.exception;
 
-import com.susanghan_guys.server.global.common.code.ErrorCode;
+import com.susanghan_guys.server.global.common.code.BaseCode;
 import lombok.Getter;
 
 @Getter
 public class BusinessException extends RuntimeException {
 
-    private final ErrorCode errorCode;
+    private final BaseCode errorCode;
 
-    public BusinessException(ErrorCode errorCode) {
+    public BusinessException(BaseCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }

--- a/src/main/java/com/susanghan_guys/server/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/susanghan_guys/server/global/exception/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.susanghan_guys.server.global.exception.handler;
 
 import com.susanghan_guys.server.global.common.CommonResponse;
+import com.susanghan_guys.server.global.common.code.BaseCode;
 import com.susanghan_guys.server.global.common.code.ErrorCode;
 import com.susanghan_guys.server.global.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +17,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<CommonResponse<Void>> handleBusinessException(BusinessException e) {
-        ErrorCode errorCode =  e.getErrorCode();
+        BaseCode errorCode =  e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(CommonResponse.failure(errorCode));

--- a/src/main/java/com/susanghan_guys/server/global/jwt/JwtProvider.java
+++ b/src/main/java/com/susanghan_guys/server/global/jwt/JwtProvider.java
@@ -1,5 +1,6 @@
 package com.susanghan_guys.server.global.jwt;
 
+import com.susanghan_guys.server.user.exception.UserAuthException;
 import com.susanghan_guys.server.user.exception.UserException;
 import com.susanghan_guys.server.user.exception.code.UserAuthErrorCode;
 import io.jsonwebtoken.*;
@@ -62,7 +63,7 @@ public class JwtProvider {
 
             return true;
         } catch (JwtException e) {
-            throw new UserException(UserAuthErrorCode.INVALID_TOKEN);
+            throw new UserAuthException(UserAuthErrorCode.INVALID_TOKEN);
         }
     }
 

--- a/src/main/java/com/susanghan_guys/server/global/security/CustomUserDetails.java
+++ b/src/main/java/com/susanghan_guys/server/global/security/CustomUserDetails.java
@@ -67,7 +67,7 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 
     @Override
     public boolean isEnabled() {
-        return true;
+        return !user.isDeleted();
     }
 
     @Override

--- a/src/main/java/com/susanghan_guys/server/oauth2/application/CustomOAuth2UserService.java
+++ b/src/main/java/com/susanghan_guys/server/oauth2/application/CustomOAuth2UserService.java
@@ -7,6 +7,8 @@ import com.susanghan_guys.server.oauth2.infrastructure.userinfo.KakaoUserInfo;
 import com.susanghan_guys.server.global.security.CustomUserDetails;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.user.domain.type.SocialLogin;
+import com.susanghan_guys.server.user.exception.UserException;
+import com.susanghan_guys.server.user.exception.code.UserErrorCode;
 import com.susanghan_guys.server.user.infrastructure.persistence.UserRepository;
 import com.susanghan_guys.server.user.infrastructure.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +57,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         if (optionalUser.isPresent()) {
             user = optionalUser.get();
+
+            if (user.isDeleted()) {
+                throw new UserException(UserErrorCode.USER_NOT_FOUND);
+            }
             isSignUp = false;
         } else {
             user = userRepository.save(UserMapper.toDomain(oAuth2UserInfo));

--- a/src/main/java/com/susanghan_guys/server/oauth2/application/CustomOAuth2UserService.java
+++ b/src/main/java/com/susanghan_guys/server/oauth2/application/CustomOAuth2UserService.java
@@ -38,7 +38,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         SocialLogin socialLogin = SocialLogin.valueOf(registrationId.toUpperCase());
 
         Map<String, Object> attributes = oAuth2User.getAttributes();
-        log.info("🌐 OAuth2 provider: {}", registrationId);
+        log.info("🌐 OAuth2 provider: {}", socialLogin);
         log.info("📦 Received attributes: {}", attributes);
 
         OAuth2UserInfo oAuth2UserInfo = getOAuth2UserInfo(socialLogin, attributes);

--- a/src/main/java/com/susanghan_guys/server/oauth2/application/CustomOAuth2UserService.java
+++ b/src/main/java/com/susanghan_guys/server/oauth2/application/CustomOAuth2UserService.java
@@ -6,6 +6,7 @@ import com.susanghan_guys.server.oauth2.infrastructure.userinfo.NaverUserInfo;
 import com.susanghan_guys.server.oauth2.infrastructure.userinfo.KakaoUserInfo;
 import com.susanghan_guys.server.global.security.CustomUserDetails;
 import com.susanghan_guys.server.user.domain.User;
+import com.susanghan_guys.server.user.domain.type.SocialLogin;
 import com.susanghan_guys.server.user.infrastructure.persistence.UserRepository;
 import com.susanghan_guys.server.user.infrastructure.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
@@ -34,22 +35,23 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        Map<String, Object> attributes = oAuth2User.getAttributes();
+        SocialLogin socialLogin = SocialLogin.valueOf(registrationId.toUpperCase());
 
+        Map<String, Object> attributes = oAuth2User.getAttributes();
         log.info("🌐 OAuth2 provider: {}", registrationId);
         log.info("📦 Received attributes: {}", attributes);
 
-        OAuth2UserInfo oAuth2UserInfo = getOAuth2UserInfo(registrationId, attributes);
-        String email = oAuth2UserInfo.getEmail();
+        OAuth2UserInfo oAuth2UserInfo = getOAuth2UserInfo(socialLogin, attributes);
+        String providerId = oAuth2UserInfo.getProviderId();
 
-        if (email == null || email.isBlank()) {
-            log.error("❌ 소셜 로그인 실패 - 이메일이 존재하지 않음. attributes = {}", attributes);
-            throw new OAuth2AuthenticationException("소셜 로그인에 이메일 정보가 없습니다.");
+        if (providerId == null || providerId.isBlank()) {
+            log.error("❌ 소셜 로그인 실패 - providerId 없음. attributes = {}", attributes);
+            throw new OAuth2AuthenticationException("소셜 로그인에 providerId 정보가 없습니다.");
         }
         boolean isSignUp;
         User user;
 
-        Optional<User> optionalUser = userRepository.findByEmail(email);
+        Optional<User> optionalUser = userRepository.findByProviderIdAndSocialLogin(providerId, socialLogin);
 
         if (optionalUser.isPresent()) {
             user = optionalUser.get();
@@ -64,12 +66,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         return new CustomUserDetails(user, updatedAttributes);
     }
 
-    private static OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
-        return switch (registrationId.toUpperCase()) {
-            case "GOOGLE" -> new GoogleUserInfo(attributes);
-            case "NAVER" -> new NaverUserInfo(attributes);
-            case "KAKAO" -> new KakaoUserInfo(attributes);
-            default -> throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다: " + registrationId);
+    private static OAuth2UserInfo getOAuth2UserInfo(SocialLogin socialLogin, Map<String, Object> attributes) {
+        return switch (socialLogin) {
+            case GOOGLE -> new GoogleUserInfo(attributes);
+            case NAVER -> new NaverUserInfo(attributes);
+            case KAKAO -> new KakaoUserInfo(attributes);
         };
     }
 }

--- a/src/main/java/com/susanghan_guys/server/oauth2/domain/OAuth2UserInfo.java
+++ b/src/main/java/com/susanghan_guys/server/oauth2/domain/OAuth2UserInfo.java
@@ -4,10 +4,8 @@ import com.susanghan_guys.server.user.domain.type.SocialLogin;
 
 public interface OAuth2UserInfo {
     String getProviderId();
-
     String getEmail();
     String getName ();
     SocialLogin getProvider();
-
     String getProfileImage();
 }

--- a/src/main/java/com/susanghan_guys/server/user/application/UserAuthService.java
+++ b/src/main/java/com/susanghan_guys/server/user/application/UserAuthService.java
@@ -11,6 +11,7 @@ import com.susanghan_guys.server.global.util.RedisUtil;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.user.dto.response.RefreshTokenResponse;
 import com.susanghan_guys.server.user.dto.response.ExchangeTokenResponse;
+import com.susanghan_guys.server.user.exception.UserAuthException;
 import com.susanghan_guys.server.user.exception.code.UserAuthErrorCode;
 import com.susanghan_guys.server.user.exception.UserException;
 import com.susanghan_guys.server.user.exception.code.UserErrorCode;
@@ -40,7 +41,7 @@ public class UserAuthService {
         String json = redisUtil.getValue(key);
 
         if (json == null) {
-            throw new UserException(UserAuthErrorCode.INVALID_AUTH_CODE);
+            throw new UserAuthException(UserAuthErrorCode.INVALID_AUTH_CODE);
         }
 
         try {
@@ -60,7 +61,7 @@ public class UserAuthService {
             return ExchangeTokenResponse.of(accessToken, refreshToken, user, isSignUp);
         } catch (JsonProcessingException e) {
             redisUtil.deleteValue(key);
-            throw new UserException(UserAuthErrorCode.TOKEN_PARSE_FAILED);
+            throw new UserAuthException(UserAuthErrorCode.TOKEN_PARSE_FAILED);
         }
     }
 
@@ -70,7 +71,7 @@ public class UserAuthService {
         String userId = claims.getSubject();
 
         RefreshToken refreshToken = refreshTokenRepository.findByUserId(Long.valueOf(userId))
-                .orElseThrow(() -> new UserException(UserAuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
+                .orElseThrow(() -> new UserAuthException(UserAuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
         refreshTokenRepository.delete(refreshToken);
 
@@ -92,7 +93,7 @@ public class UserAuthService {
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         RefreshToken savedToken = refreshTokenRepository.findByUserId(user.getId())
-                .orElseThrow(() -> new UserException(UserAuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
+                .orElseThrow(() -> new UserAuthException(UserAuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
         String newAccessToken = jwtProvider.createAccessToken(user.getId());
         String newRefreshToken = jwtProvider.createRefreshToken(user.getId());

--- a/src/main/java/com/susanghan_guys/server/user/application/UserService.java
+++ b/src/main/java/com/susanghan_guys/server/user/application/UserService.java
@@ -7,8 +7,6 @@ import com.susanghan_guys.server.user.dto.request.UserTermsRequest;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.user.dto.request.UserWithdrawalRequest;
 import com.susanghan_guys.server.user.dto.response.MyPageInfoResponse;
-import com.susanghan_guys.server.user.exception.UserException;
-import com.susanghan_guys.server.user.exception.code.UserErrorCode;
 import com.susanghan_guys.server.user.infrastructure.persistence.UserRepository;
 import com.susanghan_guys.server.user.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +22,6 @@ public class UserService {
 
     private final CurrentUserProvider currentUserProvider;
     private final UserValidator userValidator;
-    private final UserRepository userRepository;
 
     @Transactional
     public void saveUserAgreement(UserTermsRequest request) {

--- a/src/main/java/com/susanghan_guys/server/user/application/UserService.java
+++ b/src/main/java/com/susanghan_guys/server/user/application/UserService.java
@@ -61,6 +61,9 @@ public class UserService {
     @Transactional
     public void withdrawalUser(UserWithdrawalRequest request) {
         User user = currentUserProvider.getCurrentUser();
+
+        userValidator.validateUserWithdrawal(request);
+
         user.withdrawalUser(LocalDateTime.now(), request.withdrawalReason());
     }
 

--- a/src/main/java/com/susanghan_guys/server/user/application/UserService.java
+++ b/src/main/java/com/susanghan_guys/server/user/application/UserService.java
@@ -7,6 +7,8 @@ import com.susanghan_guys.server.user.dto.request.UserTermsRequest;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.user.dto.request.UserWithdrawalRequest;
 import com.susanghan_guys.server.user.dto.response.MyPageInfoResponse;
+import com.susanghan_guys.server.user.exception.UserException;
+import com.susanghan_guys.server.user.exception.code.UserErrorCode;
 import com.susanghan_guys.server.user.infrastructure.persistence.UserRepository;
 import com.susanghan_guys.server.user.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
@@ -62,7 +64,7 @@ public class UserService {
     public void withdrawalUser(UserWithdrawalRequest request) {
         User user = currentUserProvider.getCurrentUser();
 
-        userValidator.validateUserWithdrawal(request);
+        userValidator.validateUserWithdrawal(user, request);
 
         user.withdrawalUser(LocalDateTime.now(), request.withdrawalReason());
     }

--- a/src/main/java/com/susanghan_guys/server/user/application/UserService.java
+++ b/src/main/java/com/susanghan_guys/server/user/application/UserService.java
@@ -5,11 +5,15 @@ import com.susanghan_guys.server.user.dto.request.MyPageInfoRequest;
 import com.susanghan_guys.server.user.dto.request.UserOnboardingRequest;
 import com.susanghan_guys.server.user.dto.request.UserTermsRequest;
 import com.susanghan_guys.server.user.domain.User;
+import com.susanghan_guys.server.user.dto.request.UserWithdrawalRequest;
 import com.susanghan_guys.server.user.dto.response.MyPageInfoResponse;
+import com.susanghan_guys.server.user.infrastructure.persistence.UserRepository;
 import com.susanghan_guys.server.user.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +22,7 @@ public class UserService {
 
     private final CurrentUserProvider currentUserProvider;
     private final UserValidator userValidator;
+    private final UserRepository userRepository;
 
     @Transactional
     public void saveUserAgreement(UserTermsRequest request) {
@@ -51,6 +56,12 @@ public class UserService {
         user.updateUserInfo(request.name());
 
         return MyPageInfoResponse.from(user);
+    }
+
+    @Transactional
+    public void withdrawalUser(UserWithdrawalRequest request) {
+        User user = currentUserProvider.getCurrentUser();
+        user.withdrawalUser(LocalDateTime.now(), request.withdrawalReason());
     }
 
     public MyPageInfoResponse getMyPageInfo() {

--- a/src/main/java/com/susanghan_guys/server/user/domain/User.java
+++ b/src/main/java/com/susanghan_guys/server/user/domain/User.java
@@ -1,10 +1,7 @@
 package com.susanghan_guys.server.user.domain;
 
 import com.susanghan_guys.server.global.domain.BaseEntity;
-import com.susanghan_guys.server.user.domain.type.Channel;
-import com.susanghan_guys.server.user.domain.type.Purpose;
-import com.susanghan_guys.server.user.domain.type.Role;
-import com.susanghan_guys.server.user.domain.type.SocialLogin;
+import com.susanghan_guys.server.user.domain.type.*;
 import com.susanghan_guys.server.work.domain.Work;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -73,6 +70,10 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SocialLogin socialLogin;
 
+    @Column(name = "withdrawal_reason")
+    @Enumerated(EnumType.STRING)
+    private WithdrawalReason withdrawalReason;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Work> workList = new ArrayList<>();
 
@@ -91,7 +92,8 @@ public class User extends BaseEntity {
             String channelEtc,
             Purpose purpose,
             String purposeEtc,
-            SocialLogin socialLogin
+            SocialLogin socialLogin,
+             WithdrawalReason withdrawalReason
     ) {
         this.name = name;
         this.email = email;
@@ -107,6 +109,7 @@ public class User extends BaseEntity {
         this.purpose = purpose;
         this.purposeEtc = purposeEtc;
         this.socialLogin = socialLogin;
+        this.withdrawalReason = withdrawalReason;
     }
 
     public void addWork(Work work) {

--- a/src/main/java/com/susanghan_guys/server/user/domain/User.java
+++ b/src/main/java/com/susanghan_guys/server/user/domain/User.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -74,6 +75,9 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private WithdrawalReason withdrawalReason;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Work> workList = new ArrayList<>();
 
@@ -93,7 +97,8 @@ public class User extends BaseEntity {
             Purpose purpose,
             String purposeEtc,
             SocialLogin socialLogin,
-             WithdrawalReason withdrawalReason
+            WithdrawalReason withdrawalReason,
+            LocalDateTime deletedAt
     ) {
         this.name = name;
         this.email = email;
@@ -110,6 +115,7 @@ public class User extends BaseEntity {
         this.purposeEtc = purposeEtc;
         this.socialLogin = socialLogin;
         this.withdrawalReason = withdrawalReason;
+        this.deletedAt = deletedAt;
     }
 
     public void addWork(Work work) {
@@ -145,5 +151,10 @@ public class User extends BaseEntity {
 
     public void updateUserInfo(String name) {
         this.name = name;
+    }
+
+    public void withdrawalUser(LocalDateTime deletedAt, WithdrawalReason withdrawalReason) {
+        this.deletedAt = deletedAt;
+        this.withdrawalReason = withdrawalReason;
     }
 }

--- a/src/main/java/com/susanghan_guys/server/user/domain/User.java
+++ b/src/main/java/com/susanghan_guys/server/user/domain/User.java
@@ -157,4 +157,8 @@ public class User extends BaseEntity {
         this.deletedAt = deletedAt;
         this.withdrawalReason = withdrawalReason;
     }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
 }

--- a/src/main/java/com/susanghan_guys/server/user/domain/type/WithdrawalReason.java
+++ b/src/main/java/com/susanghan_guys/server/user/domain/type/WithdrawalReason.java
@@ -1,0 +1,20 @@
+package com.susanghan_guys.server.user.domain.type;
+
+import lombok.Getter;
+
+@Getter
+public enum WithdrawalReason {
+    LOW_EFFECT("학습 효과 미비"),
+    USABILITY("서비스 사용성"),
+    OTHER_SERVICE("다른 서비스 사용"),
+    NO_CONTEST("원하는 공모전 부재"),
+    UNKNOWN("어떤 무언가"),
+    SECURITY("보안 우려"),
+    ETC("기타");
+
+    private final String label;
+
+    WithdrawalReason(String label) {
+        this.label = label;
+    }
+}

--- a/src/main/java/com/susanghan_guys/server/user/dto/request/UserWithdrawalRequest.java
+++ b/src/main/java/com/susanghan_guys/server/user/dto/request/UserWithdrawalRequest.java
@@ -1,0 +1,11 @@
+package com.susanghan_guys.server.user.dto.request;
+
+import com.susanghan_guys.server.user.domain.type.WithdrawalReason;
+import lombok.Builder;
+
+@Builder
+public record UserWithdrawalRequest(
+        WithdrawalReason withdrawalReason,
+        String etc
+) {
+}

--- a/src/main/java/com/susanghan_guys/server/user/dto/request/UserWithdrawalRequest.java
+++ b/src/main/java/com/susanghan_guys/server/user/dto/request/UserWithdrawalRequest.java
@@ -1,10 +1,12 @@
 package com.susanghan_guys.server.user.dto.request;
 
 import com.susanghan_guys.server.user.domain.type.WithdrawalReason;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record UserWithdrawalRequest(
+        @NotNull
         WithdrawalReason withdrawalReason,
         String etc
 ) {

--- a/src/main/java/com/susanghan_guys/server/user/dto/request/UserWithdrawalRequest.java
+++ b/src/main/java/com/susanghan_guys/server/user/dto/request/UserWithdrawalRequest.java
@@ -1,13 +1,24 @@
 package com.susanghan_guys.server.user.dto.request;
 
 import com.susanghan_guys.server.user.domain.type.WithdrawalReason;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "사용자 탈퇴")
 public record UserWithdrawalRequest(
         @NotNull
+        @Schema(
+                description = "사용자 탈퇴 이유",
+                example = "어떤 무언가"
+        )
         WithdrawalReason withdrawalReason,
+
+        @Schema(
+                description = "사용자 탈퇴 이유 - 기타일 경우, 작성",
+                example = "어떤 무언가"
+        )
         String etc
 ) {
 }

--- a/src/main/java/com/susanghan_guys/server/user/dto/request/UserWithdrawalRequest.java
+++ b/src/main/java/com/susanghan_guys/server/user/dto/request/UserWithdrawalRequest.java
@@ -11,7 +11,7 @@ public record UserWithdrawalRequest(
         @NotNull
         @Schema(
                 description = "사용자 탈퇴 이유",
-                example = "어떤 무언가"
+                example = "UNKNOWN"
         )
         WithdrawalReason withdrawalReason,
 

--- a/src/main/java/com/susanghan_guys/server/user/exception/UserAuthException.java
+++ b/src/main/java/com/susanghan_guys/server/user/exception/UserAuthException.java
@@ -1,0 +1,12 @@
+package com.susanghan_guys.server.user.exception;
+
+import com.susanghan_guys.server.global.exception.BusinessException;
+import com.susanghan_guys.server.user.exception.code.UserAuthErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UserAuthException extends BusinessException {
+    public UserAuthException(UserAuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/susanghan_guys/server/user/exception/UserException.java
+++ b/src/main/java/com/susanghan_guys/server/user/exception/UserException.java
@@ -1,11 +1,12 @@
 package com.susanghan_guys.server.user.exception;
 
-import com.susanghan_guys.server.global.common.code.BaseCode;
+import com.susanghan_guys.server.global.exception.BusinessException;
+import com.susanghan_guys.server.user.exception.code.UserErrorCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-public class UserException extends RuntimeException {
-    private final BaseCode baseCode;
+public class UserException extends BusinessException {
+    public UserException(UserErrorCode errorCode) {
+        super(errorCode);
+    }
 }

--- a/src/main/java/com/susanghan_guys/server/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/susanghan_guys/server/user/exception/code/UserErrorCode.java
@@ -12,7 +12,7 @@ public enum UserErrorCode implements BaseCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "존재하지 않는 사용자입니다."),
     REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, 400, "필수 약관에 동의하지 않았습니다."),
     ETC_DETAIL_REQUIRED(HttpStatus.BAD_REQUEST, 400, "기타일 경우, 상세 내용을 작성해야 합니다."),
-    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, 400, "이미 탈퇴한 사용자 입니다."),
+    USER_ALREADY_DELETED(HttpStatus.CONFLICT, 409, "이미 탈퇴한 사용자 입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/susanghan_guys/server/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/susanghan_guys/server/user/exception/code/UserErrorCode.java
@@ -12,6 +12,7 @@ public enum UserErrorCode implements BaseCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "존재하지 않는 사용자입니다."),
     REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, 400, "필수 약관에 동의하지 않았습니다."),
     ETC_DETAIL_REQUIRED(HttpStatus.BAD_REQUEST, 400, "기타일 경우, 상세 내용을 작성해야 합니다."),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, 400, "이미 탈퇴한 사용자 입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/susanghan_guys/server/user/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/susanghan_guys/server/user/infrastructure/persistence/UserRepository.java
@@ -1,10 +1,11 @@
 package com.susanghan_guys.server.user.infrastructure.persistence;
 
 import com.susanghan_guys.server.user.domain.User;
+import com.susanghan_guys.server.user.domain.type.SocialLogin;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
+    Optional<User> findByProviderIdAndSocialLogin(String providerId, SocialLogin socialLogin);
 }

--- a/src/main/java/com/susanghan_guys/server/user/presentation/UserController.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/UserController.java
@@ -47,6 +47,7 @@ public class UserController implements UserSwagger {
         return CommonResponse.success(USER_INFO_UPDATE_SUCCESS, userService.updateMyPageInfo(request));
     }
 
+    @Override
     @PatchMapping("/me/withdrawal")
     public CommonResponse<String> withdrawUser(@RequestBody @Valid UserWithdrawalRequest request) {
         userService.withdrawalUser(request);

--- a/src/main/java/com/susanghan_guys/server/user/presentation/UserController.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/UserController.java
@@ -5,6 +5,7 @@ import com.susanghan_guys.server.user.application.UserService;
 import com.susanghan_guys.server.user.dto.request.MyPageInfoRequest;
 import com.susanghan_guys.server.user.dto.request.UserOnboardingRequest;
 import com.susanghan_guys.server.user.dto.request.UserTermsRequest;
+import com.susanghan_guys.server.user.dto.request.UserWithdrawalRequest;
 import com.susanghan_guys.server.user.dto.response.MyPageInfoResponse;
 import com.susanghan_guys.server.user.presentation.swagger.UserSwagger;
 import jakarta.validation.Valid;
@@ -44,5 +45,11 @@ public class UserController implements UserSwagger {
     @PatchMapping("/me")
     public CommonResponse<MyPageInfoResponse> updateMyPageInfo(@RequestBody @Valid MyPageInfoRequest request) {
         return CommonResponse.success(USER_INFO_UPDATE_SUCCESS, userService.updateMyPageInfo(request));
+    }
+
+    @PatchMapping("/me/withdrawal")
+    public CommonResponse<String> withdrawUser(@RequestBody @Valid UserWithdrawalRequest request) {
+        userService.withdrawalUser(request);
+        return CommonResponse.success(USER_WITHDRAWAL_SUCCESS, "OK");
     }
 }

--- a/src/main/java/com/susanghan_guys/server/user/presentation/swagger/UserAuthSwagger.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/swagger/UserAuthSwagger.java
@@ -1,6 +1,5 @@
 package com.susanghan_guys.server.user.presentation.swagger;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.susanghan_guys.server.global.common.CommonResponse;
 import com.susanghan_guys.server.user.dto.request.RefreshTokenRequest;
 import com.susanghan_guys.server.user.dto.response.ExchangeTokenResponse;
@@ -18,7 +17,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface UserAuthSwagger {
     @Operation(
             summary = "사용자 토큰 및 정보 조회 API",
-            description = "발급된 임시 코드를 통해 사용자의 accessToken, refreshToken 및 정보를 반환합니다."
+            description = """
+                          ## 발급된 임시 코드를 통해 사용자의 accessToken, refreshToken 및 정보를 반환합니다.
+                          ### RequestParam
+                          ---
+                          `code`: 발급된 임시 코드 (String)
+                          """
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -44,7 +48,12 @@ public interface UserAuthSwagger {
 
     @Operation(
             summary = "refreshToken 재발급 API",
-            description = "refreshToken 재발급을 진행합니다."
+            description = """
+                          ## accessToken 만료 후, 유효한 refreshToken을 통해 refreshToken 재발급을 진행합니다.
+                          ### RequestBody
+                          ---
+                          `refreshToken`: 사용자 리프레시 토큰 (String)
+                          """
     )
     @ApiResponses(value = {
             @ApiResponse(

--- a/src/main/java/com/susanghan_guys/server/user/presentation/swagger/UserSwagger.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/swagger/UserSwagger.java
@@ -4,6 +4,7 @@ import com.susanghan_guys.server.global.common.CommonResponse;
 import com.susanghan_guys.server.user.dto.request.MyPageInfoRequest;
 import com.susanghan_guys.server.user.dto.request.UserOnboardingRequest;
 import com.susanghan_guys.server.user.dto.request.UserTermsRequest;
+import com.susanghan_guys.server.user.dto.request.UserWithdrawalRequest;
 import com.susanghan_guys.server.user.dto.response.MyPageInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -66,5 +67,24 @@ public interface UserSwagger {
     })
     CommonResponse<MyPageInfoResponse> updateMyPageInfo (
             @RequestBody @Valid MyPageInfoRequest request
+    );
+
+    @Operation(
+            summary = "사용자 탈퇴 API",
+            description = """
+                          ### RequestBody
+                          ---
+                          `withdrawalReason`: 사용자 탈퇴 이유 (ENUM) \n
+                          `etc`: 기타를 선택할 시, 작성 (String)
+                          """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 탈퇴가 성공적으로 실행되었습니다."
+            )
+    })
+    CommonResponse<String> withdrawUser(
+            @RequestBody @Valid UserWithdrawalRequest request
     );
 }

--- a/src/main/java/com/susanghan_guys/server/user/presentation/swagger/UserSwagger.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/swagger/UserSwagger.java
@@ -17,7 +17,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface UserSwagger {
     @Operation(
             summary = "사용자 이용 약관 동의 API",
-            description = "사용자 이용 약관 동의를 진행합니다."
+            description = """
+                          ### RequestBody
+                          ---
+                          `isServiceAgreement`: 서비스 이용 약관 동의 (boolean) \n
+                          `isUserInfoAgreement`: 사용자 정보 수집 동의 (boolean) \n
+                          `isMarketingAgreement`: 마케팅 수신 동의 (boolean)
+                          """
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -31,7 +37,15 @@ public interface UserSwagger {
 
     @Operation(
             summary = "사용자 온보딩 API",
-            description = "사용자 온보딩을 진행합니다."
+            description = """
+                          ### RequestBody
+                          ---
+                          `role`: 주로 맡는 역할 (String) \n
+                          `purpose`: 활용 목적 (ENUM) \n
+                          `purposeEtc`: 활용 목적 - 기타일 경우, 작성 (String) \n
+                          `channel`: 알게 된 경로 (ENUM) \n
+                          `channelEtc`: 알게 된 경로 - 기타일 경우, 작성 (String)
+                          """
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -57,7 +71,11 @@ public interface UserSwagger {
 
     @Operation(
             summary = "사용자 마이 페이지 수정 API",
-            description = "사용자 마이 페이지를 수정합니다."
+            description = """
+                          ### RequestBody
+                          ---
+                          `name`: 사용자 이름 (String)
+                          """
     )
     @ApiResponses(value = {
             @ApiResponse(

--- a/src/main/java/com/susanghan_guys/server/user/validator/UserValidator.java
+++ b/src/main/java/com/susanghan_guys/server/user/validator/UserValidator.java
@@ -1,5 +1,6 @@
 package com.susanghan_guys.server.user.validator;
 
+import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.user.domain.type.Channel;
 import com.susanghan_guys.server.user.domain.type.Purpose;
 import com.susanghan_guys.server.user.domain.type.WithdrawalReason;
@@ -33,7 +34,11 @@ public class UserValidator {
         }
     }
 
-    public void validateUserWithdrawal(UserWithdrawalRequest request) {
+    public void validateUserWithdrawal(User user, UserWithdrawalRequest request) {
+        if (user.isDeleted()) {
+            throw new UserException(UserErrorCode.USER_ALREADY_DELETED);
+        }
+
         if (WithdrawalReason.ETC.equals(request.withdrawalReason())) {
             if (request.etc() == null || request.etc().isBlank()) {
                 throw new UserException(UserErrorCode.ETC_DETAIL_REQUIRED);

--- a/src/main/java/com/susanghan_guys/server/user/validator/UserValidator.java
+++ b/src/main/java/com/susanghan_guys/server/user/validator/UserValidator.java
@@ -2,8 +2,10 @@ package com.susanghan_guys.server.user.validator;
 
 import com.susanghan_guys.server.user.domain.type.Channel;
 import com.susanghan_guys.server.user.domain.type.Purpose;
+import com.susanghan_guys.server.user.domain.type.WithdrawalReason;
 import com.susanghan_guys.server.user.dto.request.UserOnboardingRequest;
 import com.susanghan_guys.server.user.dto.request.UserTermsRequest;
+import com.susanghan_guys.server.user.dto.request.UserWithdrawalRequest;
 import com.susanghan_guys.server.user.exception.UserException;
 import com.susanghan_guys.server.user.exception.code.UserErrorCode;
 import org.springframework.stereotype.Component;
@@ -26,6 +28,14 @@ public class UserValidator {
 
         if (Purpose.ETC.equals(request.purpose())) {
             if (request.purposeEtc() == null || request.purposeEtc().isBlank()) {
+                throw new UserException(UserErrorCode.ETC_DETAIL_REQUIRED);
+            }
+        }
+    }
+
+    public void validateUserWithdrawal(UserWithdrawalRequest request) {
+        if (WithdrawalReason.ETC.equals(request.withdrawalReason())) {
+            if (request.etc() == null || request.etc().isBlank()) {
                 throw new UserException(UserErrorCode.ETC_DETAIL_REQUIRED);
             }
         }


### PR DESCRIPTION
## 🔗 연관된 이슈

- #54 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 사용자 탈퇴 API

## 📸 스크린샷
- 사용자 탈퇴
<img width="502" height="356" alt="스크린샷 2025-07-19 195730" src="https://github.com/user-attachments/assets/91789568-2734-4453-a59b-5e011bbb4f63" />

- 탈퇴 후, 로그인 시도할 경우 에러 발생
<img width="1574" height="90" alt="스크린샷 2025-07-19 195811" src="https://github.com/user-attachments/assets/7b140af0-4a85-4ee6-8c8e-9779302ad2ac" />

- 연속으로 탈퇴 요청 불가능
<img width="561" height="368" alt="스크린샷 2025-07-19 195749" src="https://github.com/user-attachments/assets/595027ce-ced6-49d3-b580-03bfe7875c70" />

- 탈퇴 이유에 ETC 선택 후, 상세 내용 작성하지 않았을 경우 예외 처리
<img width="655" height="362" alt="image" src="https://github.com/user-attachments/assets/c27e9e73-ae4a-4813-8f7d-c578cf999a9f" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 사용자 탈퇴 이유를 저장해야 해서 `deletedAt`을 추가하는 방식으로 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 탈퇴 기능이 추가되었습니다. 사용자는 탈퇴 사유와 추가 설명을 입력하여 탈퇴 요청을 할 수 있습니다.
  * 사용자 탈퇴 성공 시 성공 메시지가 반환됩니다.

* **버그 수정**
  * 인증 관련 예외 처리에 세분화된 예외 클래스를 도입하여 오류 메시지와 처리 로직이 명확해졌습니다.

* **문서화**
  * 사용자 탈퇴 API 및 인증 관련 API의 Swagger 문서가 상세하게 개선되어 사용 편의성이 향상되었습니다.

* **리팩터링**
  * 소셜 로그인 처리에서 문자열 대신 열거형을 사용하여 타입 안정성을 강화했습니다.
  * 사용자 조회 방식을 이메일에서 소셜 로그인 정보 기반으로 변경하여 일관성을 높였습니다.
  * 예외 처리 구조를 개선하여 공통 예외 처리 및 사용자 예외 클래스를 재정비했습니다.
  * 사용자 활성 상태 판단 로직이 사용자 탈퇴 여부에 따라 동작하도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->