### PR TITLE
feat: 사용자 탈퇴 이유 API 수정

### DIFF
--- a/src/main/java/com/susanghan_guys/server/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/susanghan_guys/server/global/jwt/JwtAuthenticationFilter.java
@@ -47,7 +47,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                     userDetails, null, userDetails.getAuthorities()
             );
-
+            authentication.setDetails(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
         }

--- a/src/main/java/com/susanghan_guys/server/global/security/CurrentUserProvider.java
+++ b/src/main/java/com/susanghan_guys/server/global/security/CurrentUserProvider.java
@@ -5,6 +5,8 @@ import com.susanghan_guys.server.user.exception.UserException;
 import com.susanghan_guys.server.user.exception.code.UserErrorCode;
 import com.susanghan_guys.server.user.infrastructure.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -17,5 +19,10 @@ public class CurrentUserProvider {
         Long userId = SecurityUtils.getCurrentUserId();
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    public String getCurrentAccessToken() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication != null ? (String) authentication.getDetails() : null;
     }
 }

--- a/src/main/java/com/susanghan_guys/server/global/security/CustomUserDetails.java
+++ b/src/main/java/com/susanghan_guys/server/global/security/CustomUserDetails.java
@@ -67,7 +67,7 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 
     @Override
     public boolean isEnabled() {
-        return !user.isDeleted();
+        return true;
     }
 
     @Override

--- a/src/main/java/com/susanghan_guys/server/oauth2/application/CustomOAuth2UserService.java
+++ b/src/main/java/com/susanghan_guys/server/oauth2/application/CustomOAuth2UserService.java
@@ -7,8 +7,6 @@ import com.susanghan_guys.server.oauth2.infrastructure.userinfo.KakaoUserInfo;
 import com.susanghan_guys.server.global.security.CustomUserDetails;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.user.domain.type.SocialLogin;
-import com.susanghan_guys.server.user.exception.UserException;
-import com.susanghan_guys.server.user.exception.code.UserErrorCode;
 import com.susanghan_guys.server.user.infrastructure.persistence.UserRepository;
 import com.susanghan_guys.server.user.infrastructure.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
@@ -57,13 +55,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         if (optionalUser.isPresent()) {
             user = optionalUser.get();
-
-            if (user.isDeleted()) {
-                throw new UserException(UserErrorCode.USER_NOT_FOUND);
-            }
             isSignUp = false;
         } else {
-            user = userRepository.save(UserMapper.toDomain(oAuth2UserInfo));
+            user = userRepository.save(UserMapper.toEntity(oAuth2UserInfo));
             isSignUp = true;
         }
         Map<String, Object> updatedAttributes = new HashMap<>(attributes);

--- a/src/main/java/com/susanghan_guys/server/user/application/UserService.java
+++ b/src/main/java/com/susanghan_guys/server/user/application/UserService.java
@@ -7,12 +7,13 @@ import com.susanghan_guys.server.user.dto.request.UserTermsRequest;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.user.dto.request.UserWithdrawalRequest;
 import com.susanghan_guys.server.user.dto.response.MyPageInfoResponse;
+import com.susanghan_guys.server.user.infrastructure.persistence.UserRepository;
+import com.susanghan_guys.server.withdrawal.application.ReasonService;
 import com.susanghan_guys.server.user.validator.UserValidator;
+import com.susanghan_guys.server.withdrawal.validator.ReasonValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,9 @@ public class UserService {
     private final CurrentUserProvider currentUserProvider;
     private final UserValidator userValidator;
     private final UserAuthService userAuthService;
+    private final UserRepository userRepository;
+    private final ReasonService reasonService;
+    private final ReasonValidator reasonValidator;
 
     @Transactional
     public void saveUserAgreement(UserTermsRequest request) {
@@ -58,15 +62,20 @@ public class UserService {
     }
 
     @Transactional
-    public void withdrawalUser(UserWithdrawalRequest request) {
+    public void withdrawUser(UserWithdrawalRequest request) {
         User user = currentUserProvider.getCurrentUser();
         String accessToken = currentUserProvider.getCurrentAccessToken();
 
-        userValidator.validateUserWithdrawal(user, request);
+        reasonValidator.validateWithdrawalReason(request);
 
-        user.withdrawalUser(LocalDateTime.now(), request.withdrawalReasons());
+        reasonService.saveWithdrawalReason(
+                user.getName(),
+                request.withdrawalReasons(),
+                request.etc()
+        );
 
         userAuthService.logout(accessToken);
+        userRepository.delete(user);
     }
 
     public MyPageInfoResponse getMyPageInfo() {

--- a/src/main/java/com/susanghan_guys/server/user/application/UserService.java
+++ b/src/main/java/com/susanghan_guys/server/user/application/UserService.java
@@ -21,6 +21,7 @@ public class UserService {
 
     private final CurrentUserProvider currentUserProvider;
     private final UserValidator userValidator;
+    private final UserAuthService userAuthService;
 
     @Transactional
     public void saveUserAgreement(UserTermsRequest request) {
@@ -59,10 +60,13 @@ public class UserService {
     @Transactional
     public void withdrawalUser(UserWithdrawalRequest request) {
         User user = currentUserProvider.getCurrentUser();
+        String accessToken = currentUserProvider.getCurrentAccessToken();
 
         userValidator.validateUserWithdrawal(user, request);
 
         user.withdrawalUser(LocalDateTime.now(), request.withdrawalReasons());
+
+        userAuthService.logout(accessToken);
     }
 
     public MyPageInfoResponse getMyPageInfo() {

--- a/src/main/java/com/susanghan_guys/server/user/application/UserService.java
+++ b/src/main/java/com/susanghan_guys/server/user/application/UserService.java
@@ -7,7 +7,6 @@ import com.susanghan_guys.server.user.dto.request.UserTermsRequest;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.user.dto.request.UserWithdrawalRequest;
 import com.susanghan_guys.server.user.dto.response.MyPageInfoResponse;
-import com.susanghan_guys.server.user.infrastructure.persistence.UserRepository;
 import com.susanghan_guys.server.user.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -63,7 +62,7 @@ public class UserService {
 
         userValidator.validateUserWithdrawal(user, request);
 
-        user.withdrawalUser(LocalDateTime.now(), request.withdrawalReason());
+        user.withdrawalUser(LocalDateTime.now(), request.withdrawalReasons());
     }
 
     public MyPageInfoResponse getMyPageInfo() {

--- a/src/main/java/com/susanghan_guys/server/user/domain/User.java
+++ b/src/main/java/com/susanghan_guys/server/user/domain/User.java
@@ -71,9 +71,11 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SocialLogin socialLogin;
 
-    @Column(name = "withdrawal_reason")
+    @ElementCollection(fetch = FetchType.LAZY)
     @Enumerated(EnumType.STRING)
-    private WithdrawalReason withdrawalReason;
+    @CollectionTable(name = "user_withdrawal_reasons", joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "withdrawal_reason")
+    private List<WithdrawalReason> withdrawalReasons;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
@@ -97,7 +99,7 @@ public class User extends BaseEntity {
             Purpose purpose,
             String purposeEtc,
             SocialLogin socialLogin,
-            WithdrawalReason withdrawalReason,
+            List<WithdrawalReason> withdrawalReasons,
             LocalDateTime deletedAt
     ) {
         this.name = name;
@@ -114,7 +116,7 @@ public class User extends BaseEntity {
         this.purpose = purpose;
         this.purposeEtc = purposeEtc;
         this.socialLogin = socialLogin;
-        this.withdrawalReason = withdrawalReason;
+        this.withdrawalReasons = withdrawalReasons;
         this.deletedAt = deletedAt;
     }
 
@@ -153,9 +155,9 @@ public class User extends BaseEntity {
         this.name = name;
     }
 
-    public void withdrawalUser(LocalDateTime deletedAt, WithdrawalReason withdrawalReason) {
+    public void withdrawalUser(LocalDateTime deletedAt, List<WithdrawalReason> withdrawalReasons) {
         this.deletedAt = deletedAt;
-        this.withdrawalReason = withdrawalReason;
+        this.withdrawalReasons = withdrawalReasons;
     }
 
     public boolean isDeleted() {

--- a/src/main/java/com/susanghan_guys/server/user/domain/User.java
+++ b/src/main/java/com/susanghan_guys/server/user/domain/User.java
@@ -71,15 +71,6 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SocialLogin socialLogin;
 
-    @ElementCollection(fetch = FetchType.LAZY)
-    @Enumerated(EnumType.STRING)
-    @CollectionTable(name = "user_withdrawal_reasons", joinColumns = @JoinColumn(name = "user_id"))
-    @Column(name = "withdrawal_reason")
-    private List<WithdrawalReason> withdrawalReasons;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Work> workList = new ArrayList<>();
 
@@ -98,9 +89,7 @@ public class User extends BaseEntity {
             String channelEtc,
             Purpose purpose,
             String purposeEtc,
-            SocialLogin socialLogin,
-            List<WithdrawalReason> withdrawalReasons,
-            LocalDateTime deletedAt
+            SocialLogin socialLogin
     ) {
         this.name = name;
         this.email = email;
@@ -116,8 +105,6 @@ public class User extends BaseEntity {
         this.purpose = purpose;
         this.purposeEtc = purposeEtc;
         this.socialLogin = socialLogin;
-        this.withdrawalReasons = withdrawalReasons;
-        this.deletedAt = deletedAt;
     }
 
     public void addWork(Work work) {
@@ -153,14 +140,5 @@ public class User extends BaseEntity {
 
     public void updateUserInfo(String name) {
         this.name = name;
-    }
-
-    public void withdrawalUser(LocalDateTime deletedAt, List<WithdrawalReason> withdrawalReasons) {
-        this.deletedAt = deletedAt;
-        this.withdrawalReasons = withdrawalReasons;
-    }
-
-    public boolean isDeleted() {
-        return this.deletedAt != null;
     }
 }

--- a/src/main/java/com/susanghan_guys/server/user/dto/request/UserWithdrawalRequest.java
+++ b/src/main/java/com/susanghan_guys/server/user/dto/request/UserWithdrawalRequest.java
@@ -5,15 +5,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
+import java.util.List;
+
 @Builder
 @Schema(description = "사용자 탈퇴")
 public record UserWithdrawalRequest(
         @NotNull
         @Schema(
                 description = "사용자 탈퇴 이유",
-                example = "UNKNOWN"
+                example = "[\"UNKNOWN\", \"SECURITY\"]"
         )
-        WithdrawalReason withdrawalReason,
+        List<WithdrawalReason> withdrawalReasons,
 
         @Schema(
                 description = "사용자 탈퇴 이유 - 기타일 경우, 작성",

--- a/src/main/java/com/susanghan_guys/server/user/dto/request/UserWithdrawalRequest.java
+++ b/src/main/java/com/susanghan_guys/server/user/dto/request/UserWithdrawalRequest.java
@@ -1,6 +1,6 @@
 package com.susanghan_guys.server.user.dto.request;
 
-import com.susanghan_guys.server.user.domain.type.WithdrawalReason;
+import com.susanghan_guys.server.withdrawal.domain.type.ReasonType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -15,7 +15,7 @@ public record UserWithdrawalRequest(
                 description = "사용자 탈퇴 이유",
                 example = "[\"UNKNOWN\", \"SECURITY\"]"
         )
-        List<WithdrawalReason> withdrawalReasons,
+        List<ReasonType> withdrawalReasons,
 
         @Schema(
                 description = "사용자 탈퇴 이유 - 기타일 경우, 작성",

--- a/src/main/java/com/susanghan_guys/server/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/susanghan_guys/server/user/exception/code/UserErrorCode.java
@@ -12,6 +12,7 @@ public enum UserErrorCode implements BaseCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "존재하지 않는 사용자입니다."),
     REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, 400, "필수 약관에 동의하지 않았습니다."),
     ETC_DETAIL_REQUIRED(HttpStatus.BAD_REQUEST, 400, "기타일 경우, 상세 내용을 작성해야 합니다."),
+    WITHDRAWAL_REASON_REQUIRED(HttpStatus.BAD_REQUEST, 400, "탈퇴 이유가 선택되지 않았습니다."),
     USER_ALREADY_DELETED(HttpStatus.CONFLICT, 409, "이미 탈퇴한 사용자 입니다."),
     ;
 

--- a/src/main/java/com/susanghan_guys/server/user/infrastructure/mapper/UserMapper.java
+++ b/src/main/java/com/susanghan_guys/server/user/infrastructure/mapper/UserMapper.java
@@ -5,7 +5,7 @@ import com.susanghan_guys.server.user.domain.User;
 
 public class UserMapper {
 
-    public static User toDomain(OAuth2UserInfo oAuth2UserInfo) {
+    public static User toEntity(OAuth2UserInfo oAuth2UserInfo) {
         return User.builder()
                 .email(oAuth2UserInfo.getEmail())
                 .name(oAuth2UserInfo.getName())

--- a/src/main/java/com/susanghan_guys/server/user/presentation/UserController.java
+++ b/src/main/java/com/susanghan_guys/server/user/presentation/UserController.java
@@ -50,7 +50,7 @@ public class UserController implements UserSwagger {
     @Override
     @PatchMapping("/me/withdrawal")
     public CommonResponse<String> withdrawUser(@RequestBody @Valid UserWithdrawalRequest request) {
-        userService.withdrawalUser(request);
+        userService.withdrawUser(request);
         return CommonResponse.success(USER_WITHDRAWAL_SUCCESS, "OK");
     }
 }

--- a/src/main/java/com/susanghan_guys/server/user/validator/UserValidator.java
+++ b/src/main/java/com/susanghan_guys/server/user/validator/UserValidator.java
@@ -1,17 +1,12 @@
 package com.susanghan_guys.server.user.validator;
 
-import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.user.domain.type.Channel;
 import com.susanghan_guys.server.user.domain.type.Purpose;
-import com.susanghan_guys.server.user.domain.type.WithdrawalReason;
 import com.susanghan_guys.server.user.dto.request.UserOnboardingRequest;
 import com.susanghan_guys.server.user.dto.request.UserTermsRequest;
-import com.susanghan_guys.server.user.dto.request.UserWithdrawalRequest;
 import com.susanghan_guys.server.user.exception.UserException;
 import com.susanghan_guys.server.user.exception.code.UserErrorCode;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 public class UserValidator {
@@ -31,23 +26,6 @@ public class UserValidator {
 
         if (Purpose.ETC.equals(request.purpose())) {
             if (request.purposeEtc() == null || request.purposeEtc().isBlank()) {
-                throw new UserException(UserErrorCode.ETC_DETAIL_REQUIRED);
-            }
-        }
-    }
-
-    public void validateUserWithdrawal(User user, UserWithdrawalRequest request) {
-        if (user.isDeleted()) {
-            throw new UserException(UserErrorCode.USER_ALREADY_DELETED);
-        }
-
-        List<WithdrawalReason> reasons = request.withdrawalReasons();
-        if (reasons == null || reasons.isEmpty()) {
-            throw new UserException(UserErrorCode.WITHDRAWAL_REASON_REQUIRED);
-        }
-
-        if (reasons.contains(WithdrawalReason.ETC)) {
-            if (request.etc() == null || request.etc().isBlank()) {
                 throw new UserException(UserErrorCode.ETC_DETAIL_REQUIRED);
             }
         }

--- a/src/main/java/com/susanghan_guys/server/user/validator/UserValidator.java
+++ b/src/main/java/com/susanghan_guys/server/user/validator/UserValidator.java
@@ -11,6 +11,8 @@ import com.susanghan_guys.server.user.exception.UserException;
 import com.susanghan_guys.server.user.exception.code.UserErrorCode;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 public class UserValidator {
 
@@ -39,7 +41,12 @@ public class UserValidator {
             throw new UserException(UserErrorCode.USER_ALREADY_DELETED);
         }
 
-        if (WithdrawalReason.ETC.equals(request.withdrawalReason())) {
+        List<WithdrawalReason> reasons = request.withdrawalReasons();
+        if (reasons == null || reasons.isEmpty()) {
+            throw new UserException(UserErrorCode.WITHDRAWAL_REASON_REQUIRED);
+        }
+
+        if (reasons.contains(WithdrawalReason.ETC)) {
             if (request.etc() == null || request.etc().isBlank()) {
                 throw new UserException(UserErrorCode.ETC_DETAIL_REQUIRED);
             }

--- a/src/main/java/com/susanghan_guys/server/withdrawal/application/ReasonService.java
+++ b/src/main/java/com/susanghan_guys/server/withdrawal/application/ReasonService.java
@@ -1,0 +1,25 @@
+package com.susanghan_guys.server.withdrawal.application;
+
+import com.susanghan_guys.server.withdrawal.domain.Reason;
+import com.susanghan_guys.server.withdrawal.domain.type.ReasonType;
+import com.susanghan_guys.server.withdrawal.infrastructure.mapper.ReasonMapper;
+import com.susanghan_guys.server.withdrawal.infrastructure.persistence.ReasonRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReasonService {
+
+    private final ReasonRepository reasonRepository;
+
+    @Transactional
+    public void saveWithdrawalReason(String name, List<ReasonType> reasonTypes, String etc) {
+        Reason reason = ReasonMapper.toEntity(name, reasonTypes, etc);
+        reasonRepository.save(reason);
+    }
+}

--- a/src/main/java/com/susanghan_guys/server/withdrawal/domain/Reason.java
+++ b/src/main/java/com/susanghan_guys/server/withdrawal/domain/Reason.java
@@ -1,0 +1,48 @@
+package com.susanghan_guys.server.withdrawal.domain;
+
+import com.susanghan_guys.server.global.domain.BaseEntity;
+import com.susanghan_guys.server.withdrawal.domain.type.ReasonType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reason extends BaseEntity {
+
+    @Id
+    @Column(name = "reason_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_name", nullable = false)
+    private String userName;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(
+            name = "reason_types",
+            joinColumns = @JoinColumn(name = "reason_id")
+    )
+    @Column(name = "withdrawal_reason")
+    private List<ReasonType> reasonTypes;
+
+    @Column(name = "etc")
+    private String etc;
+
+    @Builder
+    public Reason(
+            String userName,
+            List<ReasonType> reasonTypes,
+            String etc
+    ) {
+        this.userName = userName;
+        this.reasonTypes = reasonTypes;
+        this.etc = etc;
+    }
+}

--- a/src/main/java/com/susanghan_guys/server/withdrawal/domain/type/ReasonType.java
+++ b/src/main/java/com/susanghan_guys/server/withdrawal/domain/type/ReasonType.java
@@ -1,9 +1,9 @@
-package com.susanghan_guys.server.user.domain.type;
+package com.susanghan_guys.server.withdrawal.domain.type;
 
 import lombok.Getter;
 
 @Getter
-public enum WithdrawalReason {
+public enum ReasonType {
     LOW_EFFECT("학습 효과 미비"),
     USABILITY("서비스 사용성"),
     OTHER_SERVICE("다른 서비스 사용"),
@@ -14,7 +14,7 @@ public enum WithdrawalReason {
 
     private final String label;
 
-    WithdrawalReason(String label) {
+    ReasonType(String label) {
         this.label = label;
     }
 }

--- a/src/main/java/com/susanghan_guys/server/withdrawal/infrastructure/mapper/ReasonMapper.java
+++ b/src/main/java/com/susanghan_guys/server/withdrawal/infrastructure/mapper/ReasonMapper.java
@@ -1,0 +1,17 @@
+package com.susanghan_guys.server.withdrawal.infrastructure.mapper;
+
+import com.susanghan_guys.server.withdrawal.domain.Reason;
+import com.susanghan_guys.server.withdrawal.domain.type.ReasonType;
+
+import java.util.List;
+
+public class ReasonMapper {
+
+    public static Reason toEntity(String name, List<ReasonType> reasonTypes, String etc) {
+        return Reason.builder()
+                .userName(name)
+                .reasonTypes(reasonTypes)
+                .etc(etc)
+                .build();
+    }
+}

--- a/src/main/java/com/susanghan_guys/server/withdrawal/infrastructure/persistence/ReasonRepository.java
+++ b/src/main/java/com/susanghan_guys/server/withdrawal/infrastructure/persistence/ReasonRepository.java
@@ -1,0 +1,7 @@
+package com.susanghan_guys.server.withdrawal.infrastructure.persistence;
+
+import com.susanghan_guys.server.withdrawal.domain.Reason;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReasonRepository extends JpaRepository<Reason, Long> {
+}

--- a/src/main/java/com/susanghan_guys/server/withdrawal/validator/ReasonValidator.java
+++ b/src/main/java/com/susanghan_guys/server/withdrawal/validator/ReasonValidator.java
@@ -1,0 +1,26 @@
+package com.susanghan_guys.server.withdrawal.validator;
+
+import com.susanghan_guys.server.user.dto.request.UserWithdrawalRequest;
+import com.susanghan_guys.server.user.exception.UserException;
+import com.susanghan_guys.server.user.exception.code.UserErrorCode;
+import com.susanghan_guys.server.withdrawal.domain.type.ReasonType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ReasonValidator {
+
+    public void validateWithdrawalReason(UserWithdrawalRequest request) {
+        List<ReasonType> reasons = request.withdrawalReasons();
+        if (reasons == null || reasons.isEmpty()) {
+            throw new UserException(UserErrorCode.WITHDRAWAL_REASON_REQUIRED);
+        }
+
+        if (reasons.contains(ReasonType.ETC)) {
+            if (request.etc() == null || request.etc().isBlank()) {
+                throw new UserException(UserErrorCode.ETC_DETAIL_REQUIRED);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

- #56

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 탈퇴 이유 단일 선택 -> 중복 선택으로 수정
- 탈퇴한 토큰으로 api 호출 불가능
- 사용자 탈퇴 hard delete로 수정 + 탈퇴 엔티티 따로 생성

## 📸 스크린샷

- 탈퇴 이유 중복 선택 가능
<img width="605" height="474" alt="스크린샷 2025-07-19 223456" src="https://github.com/user-attachments/assets/a45fac5e-a620-46a2-aee4-80e8a45c9e9c" />

- 탈퇴한 토큰으로 api 호출 불가능
<img width="491" height="360" alt="스크린샷 2025-07-19 235945" src="https://github.com/user-attachments/assets/91ac6d42-9d6a-4fa6-b24e-1a951671f61d" />

- 사용자 탈퇴 hard delete로 수정 + 탈퇴 엔티티 따로 생성
<img width="975" height="66" alt="image" src="https://github.com/user-attachments/assets/c7f938b1-d732-45ba-acc9-6def7028734d" />

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 피그마에 탈퇴하면 계정 정보 복원 불가능이라고 되어 있길래 hard delete로 수정하긴 했는데 soft가 더 좋을 것 같으면 얘기해주세유