### PR TITLE
refactor: 신청하기 api 예외 처리 방식 변경 

### DIFF
--- a/src/main/java/com/susanghan_guys/server/work/application/DcaWorkService.java
+++ b/src/main/java/com/susanghan_guys/server/work/application/DcaWorkService.java
@@ -52,7 +52,7 @@ public class DcaWorkService {
         String briefBoardUrl = s3Service.uploadFile(briefBoardFile, "dca");
         Work work = mapper.toEntity(dto, user, contest, briefBoardUrl);
         Work savedWork = workRepository.save(work);
-        workSaver.saveTeamMembers(savedWork, dto.members());
+        workSaver.saveTeamMembers(savedWork, dto.teamMembers());
 
         String uploadedAdditionalUrl = null;
         if (additionalFile != null && !additionalFile.isEmpty()) {

--- a/src/main/java/com/susanghan_guys/server/work/domain/AdditionalFile.java
+++ b/src/main/java/com/susanghan_guys/server/work/domain/AdditionalFile.java
@@ -7,8 +7,6 @@ import lombok.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 @Table(name = "additional_files")
 public class AdditionalFile {
 
@@ -26,4 +24,11 @@ public class AdditionalFile {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private FilesType type;
+
+    @Builder
+    public AdditionalFile(Work work, String value, FilesType type) {
+        this.work = work;
+        this.value = value;
+        this.type = type;
+    }
 }

--- a/src/main/java/com/susanghan_guys/server/work/domain/TeamMember.java
+++ b/src/main/java/com/susanghan_guys/server/work/domain/TeamMember.java
@@ -11,11 +11,11 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class TeamMember {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "member_id")
+    @Column(name = "team_member_id")
     private Long id;
 
     @Column(nullable = false)
@@ -24,10 +24,10 @@ public class Member {
     @Column(nullable = false)
     private String email;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "teamMember", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WorkMember> workMembers = new ArrayList<>();
 
-    public Member(String name, String email) {
+    public TeamMember(String name, String email) {
         this.name = name;
         this.email = email;
     }

--- a/src/main/java/com/susanghan_guys/server/work/domain/WorkMember.java
+++ b/src/main/java/com/susanghan_guys/server/work/domain/WorkMember.java
@@ -19,13 +19,13 @@ public class WorkMember {
     private Work work;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    @JoinColumn(name = "team_member_id", nullable = false)
+    private TeamMember teamMember;
 
-    public WorkMember(Work work, Member member) {
+    public WorkMember(Work work, TeamMember teamMember) {
         this.work = work;
-        this.member = member;
+        this.teamMember = teamMember;
         this.work.addWorkMember(this);
-        this.member.getWorkMembers().add(this);
+        this.teamMember.getWorkMembers().add(this);
     }
 }

--- a/src/main/java/com/susanghan_guys/server/work/dto/DcaWorkSubmissionRequest.java
+++ b/src/main/java/com/susanghan_guys/server/work/dto/DcaWorkSubmissionRequest.java
@@ -1,6 +1,7 @@
 package com.susanghan_guys.server.work.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 import java.util.List;
@@ -9,18 +10,22 @@ import java.util.List;
 @Schema(description = "DCA 공모전 작품 제출 요청 DTO")
 public record DcaWorkSubmissionRequest(
 
+        @NotBlank
         @Schema(description = "작품 제목", example = "작품_제목")
         String title,
 
+        @NotBlank
         @Schema(description = "작품 접수 번호", example = "P-004")
         String number,
 
+        @NotBlank
         @Schema(
                 description = "카테고리 (VISUAL, FILM, DIGICON, EXP, OUTACT)",
                 example = "FILM"
         )
         String category,
 
+        @NotBlank
         @Schema(
                 description = "브랜드(BBABBARO, TAMS, KRUSH, AIRISM, LOTTE_WORLD, " +
                         "LOTTE_GIANTS, LOTTERIA, NEXEN_TIRE, SBI_BANK)",
@@ -28,10 +33,11 @@ public record DcaWorkSubmissionRequest(
         )
         String brand,
 
+
         @Schema(description = "유튜브 링크(영상일 경우 필수)", example = "https://youtube.com/**")
         String youtubeUrl,
 
         @Schema(description = "팀원 정보(0~n명)")
-        List<TeamMemberDto> members
+        List<TeamMemberResponse> teamMembers
 
 ) {}

--- a/src/main/java/com/susanghan_guys/server/work/dto/TeamMemberResponse.java
+++ b/src/main/java/com/susanghan_guys/server/work/dto/TeamMemberResponse.java
@@ -1,15 +1,20 @@
 package com.susanghan_guys.server.work.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
 @Schema(description = "팀원 정보 DTO")
-public record TeamMemberDto(
+public record TeamMemberResponse(
 
+        @NotBlank
         @Schema(description = "이름", example = "김철수")
         String name,
 
+        @NotBlank
+        @Email
         @Schema(description = "이메일", example = "kim@example.com")
         String email
 

--- a/src/main/java/com/susanghan_guys/server/work/dto/YccWorkSubmissionRequest.java
+++ b/src/main/java/com/susanghan_guys/server/work/dto/YccWorkSubmissionRequest.java
@@ -15,6 +15,6 @@ public record YccWorkSubmissionRequest(
 
         @NotEmpty
         @Schema(description = "팀원 정보 리스트")
-        List<TeamMemberDto> members
+        List<TeamMemberResponse> members
 
 ) {}

--- a/src/main/java/com/susanghan_guys/server/work/exception/WorkException.java
+++ b/src/main/java/com/susanghan_guys/server/work/exception/WorkException.java
@@ -2,11 +2,15 @@ package com.susanghan_guys.server.work.exception;
 
 
 import com.susanghan_guys.server.global.common.code.BaseCode;
+import com.susanghan_guys.server.global.exception.BusinessException;
+import com.susanghan_guys.server.user.exception.code.UserErrorCode;
+import com.susanghan_guys.server.work.exception.code.WorkErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-public class WorkException extends RuntimeException {
-    private final BaseCode baseCode;
+public class WorkException extends BusinessException {
+    public WorkException(WorkErrorCode errorCode) {
+        super(errorCode);
+    }
 }

--- a/src/main/java/com/susanghan_guys/server/work/infrastructure/persistence/TeamMemberRepository.java
+++ b/src/main/java/com/susanghan_guys/server/work/infrastructure/persistence/TeamMemberRepository.java
@@ -1,12 +1,12 @@
 package com.susanghan_guys.server.work.infrastructure.persistence;
 
-import com.susanghan_guys.server.work.domain.Member;
+import com.susanghan_guys.server.work.domain.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+    Optional<TeamMember> findByEmail(String email);
 }

--- a/src/main/java/com/susanghan_guys/server/work/infrastructure/saver/WorkSaver.java
+++ b/src/main/java/com/susanghan_guys/server/work/infrastructure/saver/WorkSaver.java
@@ -1,17 +1,17 @@
 package com.susanghan_guys.server.work.infrastructure.saver;
 
-import jakarta.transaction.Transactional;
-import org.apache.commons.lang3.StringUtils;
 import com.susanghan_guys.server.work.domain.AdditionalFile;
-import com.susanghan_guys.server.work.domain.Member;
+import com.susanghan_guys.server.work.domain.TeamMember;
 import com.susanghan_guys.server.work.domain.Work;
 import com.susanghan_guys.server.work.domain.WorkMember;
 import com.susanghan_guys.server.work.domain.type.FilesType;
-import com.susanghan_guys.server.work.dto.TeamMemberDto;
+import com.susanghan_guys.server.work.dto.TeamMemberResponse;
 import com.susanghan_guys.server.work.infrastructure.persistence.AdditionalFileRepository;
-import com.susanghan_guys.server.work.infrastructure.persistence.MemberRepository;
+import com.susanghan_guys.server.work.infrastructure.persistence.TeamMemberRepository;
 import com.susanghan_guys.server.work.infrastructure.persistence.WorkMemberRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -22,17 +22,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WorkSaver {
 
-    private final MemberRepository memberRepository;
+    private final TeamMemberRepository teamMemberRepository;
     private final WorkMemberRepository workMemberRepository;
     private final AdditionalFileRepository additionalFileRepository;
 
-    public void saveTeamMembers(Work work, List<TeamMemberDto> members) {
-        if (members == null || members.isEmpty()) return;
+    @Transactional
+    public void saveTeamMembers(Work work, List<TeamMemberResponse> teamMembers) {
+        if (teamMembers == null || teamMembers.isEmpty()) return;
 
-        for (TeamMemberDto dto : members) {
-            Member member = memberRepository.findByEmail(dto.email())
-                    .orElseGet(() -> memberRepository.save(new Member(dto.name(), dto.email())));
-            workMemberRepository.save(new WorkMember(work, member));
+        for (TeamMemberResponse dto : teamMembers) {
+            TeamMember teamMember = teamMemberRepository.findByEmail(dto.email())
+                    .orElseGet(() -> teamMemberRepository.save(new TeamMember(dto.name(), dto.email())));
+            workMemberRepository.save(new WorkMember(work, teamMember));
         }
     }
 

--- a/src/main/java/com/susanghan_guys/server/work/presentation/WorkController.java
+++ b/src/main/java/com/susanghan_guys/server/work/presentation/WorkController.java
@@ -6,6 +6,7 @@ import com.susanghan_guys.server.work.application.YccWorkService;
 import com.susanghan_guys.server.work.dto.DcaWorkSubmissionRequest;
 import com.susanghan_guys.server.work.dto.YccWorkSubmissionRequest;
 import com.susanghan_guys.server.work.presentation.swagger.WorkSwagger;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +25,7 @@ public class WorkController implements WorkSwagger {
     @Override
     @PostMapping(value = "/dca", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public CommonResponse<String> submitDca(
-            @RequestPart DcaWorkSubmissionRequest request,
+            @RequestPart @Valid DcaWorkSubmissionRequest request,
             @RequestPart MultipartFile briefBoardFile,
             @RequestPart(required = false) MultipartFile additionalFile
     ) {
@@ -35,7 +36,7 @@ public class WorkController implements WorkSwagger {
     @Override
     @PostMapping(value = "/ycc", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public CommonResponse<String> submitYcc(
-            @RequestPart YccWorkSubmissionRequest request,
+            @RequestPart @Valid YccWorkSubmissionRequest request,
             @RequestPart MultipartFile planFile
     ) {
         yccWorkService.submit(request, planFile);

--- a/src/main/java/com/susanghan_guys/server/work/presentation/swagger/WorkSwagger.java
+++ b/src/main/java/com/susanghan_guys/server/work/presentation/swagger/WorkSwagger.java
@@ -29,7 +29,7 @@ public interface WorkSwagger {
     - number: 출품 번호
     - category: 작품 카테고리 (예: FILM, VISUAL 등)
     - brand: 브랜드명
-    - members: 팀원 정보 목록(없다면 필드 없애면 됩니다)
+    - teamMembers: 팀원 정보 목록(없다면 필드 없애면 됩니다)
     - briefBoardFile: 브리프보드 이미지 (JPG, 최대 3508x4960px, 10MB)
     
     **추가자료 조건 분기:**


### PR DESCRIPTION
## 🔗 연관된 이슈

- #59 

## 📝 작업 내용
- 필드 검증 추가
- 모호한 클래스명 변경
- JPA 생성자 관련 설정 수정
- WorkException을 전역 예외 핸들링에서 Work 도메인 예외 핸들러로 분기되도록 수정

## 📸 스크린샷


## 💬 기타
- 엔티티 구조가 꽤 바뀌어서 해당 PR을 머지-배포하기 전에 DB 한 번 밀어버리는 게 좋을 것 같습니다
- 배포 직후 공모전 데이터 INSERT 해둬야 신청하기 api가 작동하므로, 데이터 주입해둬야 합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 팀원 관련 필드 및 클래스 명칭을 일관성 있게 `TeamMember`로 변경하여 혼동을 줄였습니다.
  * 팀원 정보 입력 시 이름과 이메일의 유효성 검사(공백 및 이메일 형식)를 추가했습니다.
  * 제출 요청 시 팀원 리스트 필드명을 `members`에서 `teamMembers`로 변경했습니다.

* **문서화**
  * API 문서 내 팀원 정보 필드 설명을 최신 명칭(`teamMembers`)으로 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->