### PR TITLE
fix: Work 엔티티에서 filesType 필드 삭제

### DIFF
--- a/src/main/java/com/susanghan_guys/server/work/domain/Work.java
+++ b/src/main/java/com/susanghan_guys/server/work/domain/Work.java
@@ -42,10 +42,6 @@ public class Work extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Category category; // DCA
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "files_type")
-    private FilesType filesType; // DCA
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -76,7 +72,6 @@ public class Work extends BaseEntity {
         this.brand = brand;
         this.category = category;
         this.work = work;
-        this.filesType = filesType;
         this.user = user;
         this.contest = contest;
     }


### PR DESCRIPTION
## 🔗 연관된 이슈

- #63 

## 📝 작업 내용
- Work 엔티티에서 filesType 필드 삭제

## 📸 스크린샷
로컬 DB로 삭제 확인..
<img width="257" height="291" alt="image" src="https://github.com/user-attachments/assets/329d0f06-436f-498b-baa1-46e2d889fda6" />


## 💬 기타
- 일단 컬럼 하나만 삭제하는거라서, 아예 다시 create-drop 하는거보단 DB에서 직접 컬럼 drop하는 방식으로 삭제해두겠습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 불필요한 필드가 제거되어 데이터 구조가 간소화되었습니다.  


<!-- end of auto-generated comment: release notes by coderabbit.ai -->