### PR TITLE
fix: 픽셀 검증 삭제

### DIFF
--- a/src/main/java/com/susanghan_guys/server/work/application/validator/DcaWorkValidator.java
+++ b/src/main/java/com/susanghan_guys/server/work/application/validator/DcaWorkValidator.java
@@ -10,9 +10,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.io.IOException;
 import java.util.Optional;
 
 @Component
@@ -20,8 +17,6 @@ import java.util.Optional;
 public class DcaWorkValidator {
 
     private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
-    private static final int MAX_WIDTH = 3508;
-    private static final int MAX_HEIGHT = 4960;
     private static final String YOUTUBE_REGEX = "^https://(www\\.)?(youtube\\.com|youtu\\.be)/.+$";
 
     private final WorkRepository workRepository;
@@ -37,15 +32,6 @@ public class DcaWorkValidator {
 
         if (briefBoardFile.getSize() > MAX_FILE_SIZE) {
             throw new WorkException(WorkErrorCode.FILE_TOO_LARGE);
-        }
-
-        try {
-            BufferedImage image = ImageIO.read(briefBoardFile.getInputStream());
-            if (image == null || image.getWidth() > MAX_WIDTH || image.getHeight() > MAX_HEIGHT) {
-                throw new WorkException(WorkErrorCode.INVALID_IMAGE_DIMENSIONS);
-            }
-        } catch (IOException e) {
-            throw new WorkException(WorkErrorCode.INVALID_IMAGE_DIMENSIONS);
         }
     }
 

--- a/src/main/java/com/susanghan_guys/server/work/dto/request/DcaWorkSubmissionRequest.java
+++ b/src/main/java/com/susanghan_guys/server/work/dto/request/DcaWorkSubmissionRequest.java
@@ -24,16 +24,16 @@ public record DcaWorkSubmissionRequest(
 
         @NotNull
         @Schema(
-                description = "카테고리 (VISUAL, FILM, DIGICON, EXP, OUTACT)",
-                example = "FILM"
+                description = "카테고리 (Visual, Film, Digital Contents, Experience, Outdoor Activation)",
+                example = "Film"
         )
         Category category,
 
         @NotNull
         @Schema(
-                description = "브랜드(BBABBARO, TAMS, KRUSH, AIRISM, LOTTE_WORLD, " +
-                        "LOTTE_GIANTS, LOTTERIA, NEXEN_TIRE, SBI_BANK)",
-                example = "LOTTERIA"
+                description = "브랜드(빼빼로, 탐스, 크러시, 에어리즘, 롯데월드, " +
+                        "롯데자이언츠, 롯데리아, 넥센타이어, SBI 저축은행 사이다뱅크)",
+                example = "빼빼로"
         )
         Brand brand,
 

--- a/src/main/java/com/susanghan_guys/server/work/exception/code/WorkErrorCode.java
+++ b/src/main/java/com/susanghan_guys/server/work/exception/code/WorkErrorCode.java
@@ -16,7 +16,6 @@ public enum WorkErrorCode implements BaseCode {
     INVALID_ADDITIONAL_FILE_TYPE(HttpStatus.BAD_REQUEST, 400, "추가 자료의 형식이 잘못되었습니다."),
     YOUTUBE_URL_REQUIRED(HttpStatus.BAD_REQUEST, 400, "영상 카테고리는 유튜브 링크 제출이 필수입니다."),
     YOUTUBE_NOT_ALLOWED_FOR_NON_FILM(HttpStatus.BAD_REQUEST, 400, "비영상 카테고리에는 유튜브 링크를 제출할 수 없습니다."),
-    INVALID_IMAGE_DIMENSIONS(HttpStatus.BAD_REQUEST, 400, "브리프보드는 최대 3508x4960 픽셀의 JPG 파일이어야 합니다."),
     INVALID_BRIEF_BOARD_TYPE(HttpStatus.BAD_REQUEST, 400, "브리프보드는 JPG 형식이어야 합니다."),
 
     // YCC


### PR DESCRIPTION
## 🔗 연관된 이슈

- #93 

## 📝 작업 내용
- 픽셀 검증 삭제
- DCA 신청하기 스웨거 ENUM 예시 프론트 기준으로 업데이트

## 📸 스크린샷


## 💬 리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 브리프보드 JPG 업로드에서 가로·세로 픽셀 제한을 제거해 업로드 유연성이 향상되었습니다. 파일 형식(JPG)과 최대 용량 제한은 그대로 적용되며, 기존 이미지 크기 관련 오류는 더 이상 발생하지 않습니다.
* 문서
  * API 스펙의 카테고리·브랜드 설명과 예시를 실제 명칭으로 갱신해 가독성과 일관성을 개선했습니다(영문/국문 표기 정비).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->