### PR TITLE
feat: 내 리포트 공모전 팀원 조회 API 및 리포트 상태 저장

### DIFF
--- a/src/main/java/com/susanghan_guys/server/file/presentation/swagger/FileSwagger.java
+++ b/src/main/java/com/susanghan_guys/server/file/presentation/swagger/FileSwagger.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@Tag(name = "[파일 변환]", description = "DCA, YCC 작품 내 PDF -> IMAGE 변환 관련 API")
+@Tag(name = "[백엔드 내부 - 파일 변환]", description = "DCA, YCC 작품 내 PDF -> IMAGE 변환 관련 API")
 public interface FileSwagger {
     @Operation(
             summary = "DCA 작품 PDF -> IMAGE 변환 API",

--- a/src/main/java/com/susanghan_guys/server/mail/presentation/swagger/MailSwagger.java
+++ b/src/main/java/com/susanghan_guys/server/mail/presentation/swagger/MailSwagger.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "[메일]", description = "메일 전송 관련 API")
+@Tag(name = "[백엔드 내부 - 메일]", description = "메일 전송 관련 API")
 public interface MailSwagger {
     @Operation(
             summary = "완료된 리포트 메일 전송 API",

--- a/src/main/java/com/susanghan_guys/server/personalwork/application/YccWorkEvaluationService.java
+++ b/src/main/java/com/susanghan_guys/server/personalwork/application/YccWorkEvaluationService.java
@@ -17,6 +17,7 @@ import com.susanghan_guys.server.personalwork.infrastructure.persistence.DetailE
 import com.susanghan_guys.server.personalwork.infrastructure.persistence.EvaluationRepository;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.work.domain.Work;
+import com.susanghan_guys.server.work.domain.type.ReportStatus;
 import com.susanghan_guys.server.work.exception.WorkException;
 import com.susanghan_guys.server.work.exception.code.WorkErrorCode;
 import com.susanghan_guys.server.work.infrastructure.persistence.WorkRepository;
@@ -80,6 +81,7 @@ public class YccWorkEvaluationService {
             List<DetailEval> detailEvals = getOrCreateDetailEvaluation(workId, evaluation.getType());
             evaluation.updateScore(detailEvals);
         }
+        work.updateReportStatus(ReportStatus.COMPLETED);
 
         return evaluations;
     }

--- a/src/main/java/com/susanghan_guys/server/work/application/ReportService.java
+++ b/src/main/java/com/susanghan_guys/server/work/application/ReportService.java
@@ -1,6 +1,5 @@
 package com.susanghan_guys.server.work.application;
 
-import com.susanghan_guys.server.global.exception.BusinessException;
 import com.susanghan_guys.server.global.security.CurrentUserProvider;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.work.application.validator.ReportValidator;

--- a/src/main/java/com/susanghan_guys/server/work/application/ReportService.java
+++ b/src/main/java/com/susanghan_guys/server/work/application/ReportService.java
@@ -56,10 +56,12 @@ public class ReportService {
     }
 
     public ReportInfoResponse getReportInfo(Long workId) {
-        currentUserProvider.getCurrentUser();
+        User user = currentUserProvider.getCurrentUser();
 
         Work work = workRepository.findById(workId)
                 .orElseThrow(() -> new WorkException(WorkErrorCode.WORK_NOT_FOUND));
+
+        reportValidator.validateReportInfo(user, work);
 
         return ReportInfoResponse.from(work);
     }

--- a/src/main/java/com/susanghan_guys/server/work/application/ReportService.java
+++ b/src/main/java/com/susanghan_guys/server/work/application/ReportService.java
@@ -8,6 +8,7 @@ import com.susanghan_guys.server.work.domain.WorkVisibility;
 import com.susanghan_guys.server.work.dto.request.ReportCodeRequest;
 import com.susanghan_guys.server.work.dto.request.ReportDeletionRequest;
 import com.susanghan_guys.server.work.dto.response.MyReportListResponse;
+import com.susanghan_guys.server.work.dto.response.ReportInfoResponse;
 import com.susanghan_guys.server.work.exception.WorkException;
 import com.susanghan_guys.server.work.exception.code.WorkErrorCode;
 import com.susanghan_guys.server.work.infrastructure.persistence.WorkRepository;
@@ -52,6 +53,15 @@ public class ReportService {
                 : workRepository.findDeletableWorks(workIds, user.getId());
 
         return MyReportListResponse.of(works, deletableWorks);
+    }
+
+    public ReportInfoResponse getReportInfo(Long workId) {
+        currentUserProvider.getCurrentUser();
+
+        Work work = workRepository.findById(workId)
+                .orElseThrow(() -> new WorkException(WorkErrorCode.WORK_NOT_FOUND));
+
+        return ReportInfoResponse.from(work);
     }
 
     @Transactional

--- a/src/main/java/com/susanghan_guys/server/work/application/validator/ReportValidator.java
+++ b/src/main/java/com/susanghan_guys/server/work/application/validator/ReportValidator.java
@@ -18,6 +18,12 @@ public class ReportValidator {
     private final WorkRepository workRepository;
     private final WorkVisibilityRepository workVisibilityRepository;
 
+    public void validateReportInfo(User user, Work work) {
+        if (work.getUser().getId().equals(user.getId())) {
+            throw new WorkException(WorkErrorCode.REPORT_UNAUTHORIZED);
+        }
+    }
+
     public void validateReportCode(User user, Work work, ReportCodeRequest request) {
         if (work.getUser().getId().equals(user.getId())) {
             throw new WorkException(WorkErrorCode.APPLICANTS_NOT_CODE_VERIFIED);

--- a/src/main/java/com/susanghan_guys/server/work/domain/Work.java
+++ b/src/main/java/com/susanghan_guys/server/work/domain/Work.java
@@ -115,4 +115,8 @@ public class Work extends BaseEntity {
     public void markMailSent() {
         this.mailSentAt = LocalDateTime.now();
     }
+
+    public void updateReportStatus(ReportStatus reportStatus) {
+        this.reportStatus = reportStatus;
+    }
 }

--- a/src/main/java/com/susanghan_guys/server/work/dto/response/ReportInfoResponse.java
+++ b/src/main/java/com/susanghan_guys/server/work/dto/response/ReportInfoResponse.java
@@ -1,0 +1,32 @@
+package com.susanghan_guys.server.work.dto.response;
+
+import com.susanghan_guys.server.work.domain.Work;
+import com.susanghan_guys.server.work.domain.type.Brand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ReportInfoResponse(
+        @Schema(description = "공모전 이름", example = "YCC")
+        String contestName,
+
+        @Schema(description = "브랜드", example = "롯데리아")
+        Brand brand,
+
+        @Schema(description = "공모전 팀원", example = "[\"김철수\", \"주정빈\", \"강수진\"]")
+        List<String> workMembers
+) {
+    public static ReportInfoResponse from(Work work) {
+        return ReportInfoResponse.builder()
+                .contestName(work.getContest().getTitle())
+                .brand(work.getBrand())
+                .workMembers(
+                        work.getWorkMembers().stream()
+                                .map(workMember -> workMember.getTeamMember().getName())
+                                .toList()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/susanghan_guys/server/work/exception/code/WorkErrorCode.java
+++ b/src/main/java/com/susanghan_guys/server/work/exception/code/WorkErrorCode.java
@@ -33,6 +33,7 @@ public enum WorkErrorCode implements BaseCode {
     APPLICANTS_NOT_CODE_VERIFIED(HttpStatus.FORBIDDEN, 403, "신청자는 리포트 코드 인증이 불가능합니다."),
     APPLICANTS_NOT_DELETED(HttpStatus.FORBIDDEN, 403, "신청자는 리포트를 삭제할 수 없습니다."),
     DELETABLE_WORK_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "삭제 가능한 리포트가 존재하지 않습니다."),
+    REPORT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 401, "리포트 열람 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/susanghan_guys/server/work/exception/code/WorkErrorCode.java
+++ b/src/main/java/com/susanghan_guys/server/work/exception/code/WorkErrorCode.java
@@ -33,7 +33,7 @@ public enum WorkErrorCode implements BaseCode {
     APPLICANTS_NOT_CODE_VERIFIED(HttpStatus.FORBIDDEN, 403, "신청자는 리포트 코드 인증이 불가능합니다."),
     APPLICANTS_NOT_DELETED(HttpStatus.FORBIDDEN, 403, "신청자는 리포트를 삭제할 수 없습니다."),
     DELETABLE_WORK_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "삭제 가능한 리포트가 존재하지 않습니다."),
-    REPORT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 401, "리포트 열람 권한이 없습니다."),
+    REPORT_UNAUTHORIZED(HttpStatus.FORBIDDEN, 403, "리포트 열람 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/susanghan_guys/server/work/presentation/ReportController.java
+++ b/src/main/java/com/susanghan_guys/server/work/presentation/ReportController.java
@@ -5,6 +5,7 @@ import com.susanghan_guys.server.work.application.ReportService;
 import com.susanghan_guys.server.work.dto.request.ReportCodeRequest;
 import com.susanghan_guys.server.work.dto.request.ReportDeletionRequest;
 import com.susanghan_guys.server.work.dto.response.MyReportListResponse;
+import com.susanghan_guys.server.work.dto.response.ReportInfoResponse;
 import com.susanghan_guys.server.work.presentation.swagger.ReportSwagger;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -27,6 +28,12 @@ public class ReportController implements ReportSwagger {
             @RequestParam(required = false) String name
     ) {
         return CommonResponse.success(MY_REPORTS_RETRIEVED_SUCCESS, reportService.getMyReports(name, page));
+    }
+
+    @Override
+    @GetMapping("/{workId}")
+    public CommonResponse<ReportInfoResponse> getReportInfo(@PathVariable(name = "workId") Long workId) {
+        return CommonResponse.success(MY_REPORTS_RETRIEVED_SUCCESS, reportService.getReportInfo(workId));
     }
 
     @Override

--- a/src/main/java/com/susanghan_guys/server/work/presentation/swagger/ReportSwagger.java
+++ b/src/main/java/com/susanghan_guys/server/work/presentation/swagger/ReportSwagger.java
@@ -4,6 +4,7 @@ import com.susanghan_guys.server.global.common.CommonResponse;
 import com.susanghan_guys.server.work.dto.request.ReportCodeRequest;
 import com.susanghan_guys.server.work.dto.request.ReportDeletionRequest;
 import com.susanghan_guys.server.work.dto.response.MyReportListResponse;
+import com.susanghan_guys.server.work.dto.response.ReportInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -29,6 +30,20 @@ public interface ReportSwagger {
     CommonResponse<MyReportListResponse> getMyReports(
             @RequestParam(name = "page") @Min(0) Integer page,
             @RequestParam(required = false) String name
+    );
+
+    @Operation(
+            summary = "리포트 정보 조회 API",
+            description = "분석 완료된 출품작에 대한 리포트 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "리포트 정보에 대한 조회가 성공적으로 실행되었습니다."
+            )
+    })
+    CommonResponse<ReportInfoResponse> getReportInfo(
+            @PathVariable(name = "workId") Long workId
     );
 
     @Operation(


### PR DESCRIPTION
## 🔗 연관된 이슈

- #107

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 내 리포트 공모전 팀원 및 공모전 종류, 브랜드 조회 API
- open ai 호출 후, 리포트 상태 `COMPLETED`로 수정

## 📸 스크린샷
<img width="631" height="360" alt="image" src="https://github.com/user-attachments/assets/c4f20af9-5325-4bdb-8402-96061eda2bab" />
<img width="530" height="452" alt="스크린샷 2025-08-28 172713" src="https://github.com/user-attachments/assets/784b5941-ffbd-40be-9c3f-8ed026e43e48" />

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- db에서 상태 바뀐 거 확인했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 보고서 정보 조회 API 추가: 작품 ID로 대회명·브랜드·참여 멤버 반환.
  - 평가 완료 시 해당 작품의 보고서 상태가 자동으로 ‘완료’로 갱신.
- 문서화
  - 파일 변환·메일 관련 API 태그를 “백엔드 내부”로 명확화.
  - 보고서 정보 조회 엔드포인트 및 응답 스키마를 스웨거에 추가.
- 보안/검증
  - 본인 작품에 대한 리포트 열람을 차단하는 권한 검증 로직 및 관련 에러 코드 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->