### PR TITLE
fix: 리포트 코드 인증 사용자 리포트 조회 버그

### DIFF
--- a/src/main/java/com/susanghan_guys/server/personalwork/application/YccWorkEvaluationService.java
+++ b/src/main/java/com/susanghan_guys/server/personalwork/application/YccWorkEvaluationService.java
@@ -21,6 +21,7 @@ import com.susanghan_guys.server.work.domain.type.ReportStatus;
 import com.susanghan_guys.server.work.exception.WorkException;
 import com.susanghan_guys.server.work.exception.code.WorkErrorCode;
 import com.susanghan_guys.server.work.infrastructure.persistence.WorkRepository;
+import com.susanghan_guys.server.work.infrastructure.persistence.WorkVisibilityRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,7 @@ public class YccWorkEvaluationService {
     private final OpenAiPort openAiPort;
     private final OpenAiFactory openAiFactory;
     private final WorkRepository workRepository;
+    private final WorkVisibilityRepository workVisibilityRepository;
     private final EvaluationRepository evaluationRepository;
     private final DetailEvalRepository detailEvalRepository;
     private final PersonalWorkValidator personalWorkValidator;
@@ -43,9 +45,14 @@ public class YccWorkEvaluationService {
     public YccWorkEvaluationResponse createYccWorkEvaluation(Long workId) {
         User user = currentUserProvider.getCurrentUser();
 
-        personalWorkValidator.validatePersonalWorkOwner(workId, user);
-
-        List<Evaluation> evaluations = getOrCreateEvaluation(workId);
+        List<Evaluation> evaluations;
+        if (personalWorkValidator.isOwner(workId, user.getId())) {
+            evaluations = getOrCreateEvaluation(workId);
+        } else if (workVisibilityRepository.existsByWorkIdAndUserIdAndVisibleTrue(workId, user.getId())) {
+            evaluations = evaluationRepository.findAllByWorkId(workId);
+        } else {
+            throw new WorkException(WorkErrorCode.REPORT_UNAUTHORIZED);
+        }
 
         return EvaluationMapper.toResponse(evaluations);
     }

--- a/src/main/java/com/susanghan_guys/server/personalwork/application/validator/PersonalWorkValidator.java
+++ b/src/main/java/com/susanghan_guys/server/personalwork/application/validator/PersonalWorkValidator.java
@@ -16,6 +16,13 @@ public class PersonalWorkValidator {
 
     private final WorkRepository workRepository;
 
+    public boolean isOwner(Long workId, Long userId) {
+        Work work = workRepository.findById(workId)
+                .orElseThrow(() -> new PersonalWorkException(PersonalWorkErrorCode.WORK_NOT_FOUND));
+
+        return work.getUser().getId().equals(userId);
+    }
+
     public void validatePersonalWorkOwner(Long workId, User user) {
         Work work = workRepository.findById(workId)
                 .orElseThrow(() -> new PersonalWorkException(PersonalWorkErrorCode.WORK_NOT_FOUND));

--- a/src/main/java/com/susanghan_guys/server/work/application/validator/ReportValidator.java
+++ b/src/main/java/com/susanghan_guys/server/work/application/validator/ReportValidator.java
@@ -19,7 +19,8 @@ public class ReportValidator {
     private final WorkVisibilityRepository workVisibilityRepository;
 
     public void validateReportInfo(User user, Work work) {
-        if (!work.getUser().getId().equals(user.getId())) {
+        boolean isVisible = workVisibilityRepository.existsByWorkIdAndUserIdAndVisibleTrue(work.getId(), user.getId());
+        if (!work.getUser().getId().equals(user.getId()) && !isVisible) {
             throw new WorkException(WorkErrorCode.REPORT_UNAUTHORIZED);
         }
     }

--- a/src/main/java/com/susanghan_guys/server/work/dto/response/ReportInfoResponse.java
+++ b/src/main/java/com/susanghan_guys/server/work/dto/response/ReportInfoResponse.java
@@ -8,7 +8,11 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
+@Schema(description = "내 리포트 정보 조회 API")
 public record ReportInfoResponse(
+        @Schema(description = "출품작 이름", example = "너에게서 나를 보다")
+        String workName,
+
         @Schema(description = "공모전 이름", example = "YCC")
         String contestName,
 
@@ -20,6 +24,7 @@ public record ReportInfoResponse(
 ) {
     public static ReportInfoResponse from(Work work) {
         return ReportInfoResponse.builder()
+                .workName(work.getTitle())
                 .contestName(work.getContest().getTitle())
                 .brand(work.getBrand())
                 .workMembers(


### PR DESCRIPTION
## 🔗 연관된 이슈

- #109 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 리포트 신청자가 아닌 코드 인증 사용자일 경우, 조회 불가능 오류 해결

## 📸 스크린샷
- 작품 분석 조회
> <img width="1737" height="740" alt="스크린샷 2025-08-28 231459" src="https://github.com/user-attachments/assets/27aacb87-28f0-45fc-91fe-44331c267e8f" /> <img width="743" height="377" alt="image" src="https://github.com/user-attachments/assets/449065ec-c57d-4f63-8885-a4758199622e" />

- 리포트 정보 조회
> <img width="552" height="475" alt="image" src="https://github.com/user-attachments/assets/dd57c3ba-901b-4c53-b6ea-3307e09e0f67" /> <img width="591" height="358" alt="image" src="https://github.com/user-attachments/assets/119e2829-90f2-41a0-a819-d161eca3195d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 리포트·평가 권한에 공개 범위(visibility) 기반 접근 허용: 소유자 외에도 열람 권한이 있는 사용자는 조회 가능, 미가시 시 접근 차단.
  - 평가 생성 로직 개선: 소유자는 생성/조회, 권한 있는 비소유자는 기존 평가만 조회.
  - 리포트 정보 응답에 출품작 이름(workName) 필드 추가.

- 문서화
  - 리포트 정보 응답에 스키마 설명 및 예시 주석 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->