### PR TITLE
feat: 리포트 코드 인증 API 수정

### DIFF
--- a/src/main/java/com/susanghan_guys/server/work/application/ReportService.java
+++ b/src/main/java/com/susanghan_guys/server/work/application/ReportService.java
@@ -82,15 +82,15 @@ public class ReportService {
     }
 
     @Transactional
-    public ReportCodeResponse verifyReportCode(ReportCodeRequest request) {
+    public ReportCodeResponse verifyReportCode(Long workId, ReportCodeRequest request) {
         User user = currentUserProvider.getCurrentUser();
 
-        Work work = workRepository.findByCode(request.code())
+        Work work = workRepository.findById(workId)
                 .orElseThrow(() -> new WorkException(WorkErrorCode.WORK_NOT_FOUND));
 
         reportValidator.validateReportCode(user, work, request);
 
-        if (workVisibilityRepository.findByWorkIdAndUserId(work.getId(), user.getId()).isEmpty()) {
+        if (workVisibilityRepository.findByWorkIdAndUserId(workId, user.getId()).isEmpty()) {
             workVisibilityRepository.save(WorkVisibility.of(user, work, true));
         }
         return ReportCodeResponse.from(work);

--- a/src/main/java/com/susanghan_guys/server/work/presentation/ReportController.java
+++ b/src/main/java/com/susanghan_guys/server/work/presentation/ReportController.java
@@ -45,9 +45,12 @@ public class ReportController implements ReportSwagger {
     }
 
     @Override
-    @PostMapping("/verify-code")
-    public CommonResponse<ReportCodeResponse> verifyReportCode(@RequestBody @Valid ReportCodeRequest request) {
-        return CommonResponse.success(REPORTS_CODE_VERIFY_SUCCESS, reportService.verifyReportCode(request));
+    @PostMapping("/{workId}/verify-code")
+    public CommonResponse<ReportCodeResponse> verifyReportCode(
+            @PathVariable(name = "workId") Long workId,
+            @RequestBody @Valid ReportCodeRequest request
+    ) {
+        return CommonResponse.success(REPORTS_CODE_VERIFY_SUCCESS, reportService.verifyReportCode(workId, request));
     }
 
     @Override

--- a/src/main/java/com/susanghan_guys/server/work/presentation/swagger/ReportSwagger.java
+++ b/src/main/java/com/susanghan_guys/server/work/presentation/swagger/ReportSwagger.java
@@ -73,6 +73,7 @@ public interface ReportSwagger {
             )
     })
     CommonResponse<ReportCodeResponse> verifyReportCode(
+            @PathVariable(name = "workId") Long workId,
             @RequestBody @Valid ReportCodeRequest request
     );
 


### PR DESCRIPTION
## 🔗 연관된 이슈

- #118

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 프론트 요청으로 리포트 코드 인증 로직 원래대로 수정

## 📸 스크린샷
> 
<img width="550" height="386" alt="image" src="https://github.com/user-attachments/assets/ad0f9d58-ebe9-4001-bdfb-5f7ed97b95b9" />
<img width="602" height="353" alt="image" src="https://github.com/user-attachments/assets/1ac1911a-751e-40ac-8aca-31df64648818" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 없음

- 리팩터
  - 보고서 코드 검증 API가 작업 ID를 경로 변수로 요구하도록 변경됨: POST /{workId}/verify-code
  - 요청 본문은 기존과 동일하나, 호출 시 workId를 경로에 포함해야 함

- 문서
  - API 문서/스웨거에 변경된 경로와 파라미터 반영

<!-- end of auto-generated comment: release notes by coderabbit.ai -->