### PR TITLE
fix: QA에서 발견한 수정 사항 반영

### DIFF
--- a/src/main/java/com/susanghan_guys/server/feedback/application/FeedbackService.java
+++ b/src/main/java/com/susanghan_guys/server/feedback/application/FeedbackService.java
@@ -6,6 +6,8 @@ import com.susanghan_guys.server.feedback.exception.FeedbackException;
 import com.susanghan_guys.server.feedback.exception.code.FeedbackErrorCode;
 import com.susanghan_guys.server.feedback.infrastructure.mapper.FeedbackMapper;
 import com.susanghan_guys.server.feedback.infrastructure.persistence.FeedbackRepository;
+import com.susanghan_guys.server.global.security.CurrentUserProvider;
+import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.work.domain.Work;
 import com.susanghan_guys.server.work.exception.WorkException;
 import com.susanghan_guys.server.work.exception.code.WorkErrorCode;
@@ -21,17 +23,20 @@ public class FeedbackService {
 
     private final WorkRepository workRepository;
     private final FeedbackRepository feedbackRepository;
+    private final CurrentUserProvider currentUserProvider;
 
     @Transactional
     public void createFeedback(Long workId, FeedbackRequest request) {
+        User user = currentUserProvider.getCurrentUser();
+
         Work work = workRepository.findById(workId)
                 .orElseThrow(() -> new WorkException(WorkErrorCode.WORK_NOT_FOUND));
 
-        if (feedbackRepository.existsByWorkId(workId)) {
+        if (feedbackRepository.existsByWorkAndUser(work, user)) {
             throw new FeedbackException(FeedbackErrorCode.FEEDBACK_ALREADY_EXIST);
         }
 
-        Feedback feedback = FeedbackMapper.toEntity(request.score(), request.content(), work);
+        Feedback feedback = FeedbackMapper.toEntity(request.score(), request.content(), user, work);
 
         feedbackRepository.save(feedback);
     }

--- a/src/main/java/com/susanghan_guys/server/feedback/application/FeedbackService.java
+++ b/src/main/java/com/susanghan_guys/server/feedback/application/FeedbackService.java
@@ -13,6 +13,7 @@ import com.susanghan_guys.server.work.exception.WorkException;
 import com.susanghan_guys.server.work.exception.code.WorkErrorCode;
 import com.susanghan_guys.server.work.infrastructure.persistence.WorkRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,12 +33,12 @@ public class FeedbackService {
         Work work = workRepository.findById(workId)
                 .orElseThrow(() -> new WorkException(WorkErrorCode.WORK_NOT_FOUND));
 
-        if (feedbackRepository.existsByWorkAndUser(work, user)) {
-            throw new FeedbackException(FeedbackErrorCode.FEEDBACK_ALREADY_EXIST);
-        }
-
         Feedback feedback = FeedbackMapper.toEntity(request.score(), request.content(), user, work);
 
-        feedbackRepository.save(feedback);
+        try {
+            feedbackRepository.save(feedback);
+        } catch (DataIntegrityViolationException e) {
+            throw new FeedbackException(FeedbackErrorCode.FEEDBACK_ALREADY_EXIST);
+        }
     }
 }

--- a/src/main/java/com/susanghan_guys/server/feedback/domain/Feedback.java
+++ b/src/main/java/com/susanghan_guys/server/feedback/domain/Feedback.java
@@ -1,6 +1,7 @@
 package com.susanghan_guys.server.feedback.domain;
 
 import com.susanghan_guys.server.global.domain.BaseEntity;
+import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.work.domain.Work;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -24,18 +25,24 @@ public class Feedback extends BaseEntity {
     @Column(name = "content", nullable = false)
     private String content;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "work_id", nullable = false, unique = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "work_id", nullable = false)
     private Work work;
 
     @Builder
     public Feedback(
             Integer score,
             String content,
+            User user,
             Work work
     ) {
         this.score = score;
         this.content = content;
+        this.user = user;
         this.work = work;
     }
 }

--- a/src/main/java/com/susanghan_guys/server/feedback/domain/Feedback.java
+++ b/src/main/java/com/susanghan_guys/server/feedback/domain/Feedback.java
@@ -10,6 +10,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name = "UK_feedback_user_work",
+                columnNames = {"user_id", "work_id"}
+        )
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Feedback extends BaseEntity {

--- a/src/main/java/com/susanghan_guys/server/feedback/infrastructure/mapper/FeedbackMapper.java
+++ b/src/main/java/com/susanghan_guys/server/feedback/infrastructure/mapper/FeedbackMapper.java
@@ -1,14 +1,16 @@
 package com.susanghan_guys.server.feedback.infrastructure.mapper;
 
 import com.susanghan_guys.server.feedback.domain.Feedback;
+import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.work.domain.Work;
 
 public class FeedbackMapper {
 
-    public static Feedback toEntity(Integer score, String content, Work work) {
+    public static Feedback toEntity(Integer score, String content, User user, Work work) {
         return Feedback.builder()
                 .score(score)
                 .content(content)
+                .user(user)
                 .work(work)
                 .build();
     }

--- a/src/main/java/com/susanghan_guys/server/feedback/infrastructure/persistence/FeedbackRepository.java
+++ b/src/main/java/com/susanghan_guys/server/feedback/infrastructure/persistence/FeedbackRepository.java
@@ -1,8 +1,10 @@
 package com.susanghan_guys.server.feedback.infrastructure.persistence;
 
 import com.susanghan_guys.server.feedback.domain.Feedback;
+import com.susanghan_guys.server.user.domain.User;
+import com.susanghan_guys.server.work.domain.Work;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
-    boolean existsByWorkId(Long workId);
+    boolean existsByWorkAndUser(Work work, User user);
 }

--- a/src/main/java/com/susanghan_guys/server/mail/application/MailService.java
+++ b/src/main/java/com/susanghan_guys/server/mail/application/MailService.java
@@ -68,6 +68,9 @@ public class MailService {
         ), template);
 
         for (WorkMember workMember : work.getWorkMembers()) {
+            if (work.getUser().getEmail().equals(workMember.getTeamMember().getEmail())) {
+                continue;
+            }
             personalizeMail(new MailRequest(
                     workMember.getTeamMember().getEmail(),
                     workMember.getTeamMember().getName(),

--- a/src/main/java/com/susanghan_guys/server/personalwork/application/DcaWorkEvaluationService.java
+++ b/src/main/java/com/susanghan_guys/server/personalwork/application/DcaWorkEvaluationService.java
@@ -17,7 +17,6 @@ import com.susanghan_guys.server.personalwork.infrastructure.persistence.DetailE
 import com.susanghan_guys.server.personalwork.infrastructure.persistence.EvaluationRepository;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.work.domain.Work;
-import com.susanghan_guys.server.work.domain.type.ReportStatus;
 import com.susanghan_guys.server.work.exception.WorkException;
 import com.susanghan_guys.server.work.exception.code.WorkErrorCode;
 import com.susanghan_guys.server.work.infrastructure.persistence.WorkRepository;
@@ -98,7 +97,6 @@ public class DcaWorkEvaluationService {
             List<DetailEval> detailEvals = getOrCreateDetailEvaluation(workId, evaluation.getType());
             evaluation.updateScore(detailEvals);
         }
-        work.updateReportStatus(ReportStatus.COMPLETED);
 
         return evaluations;
     }

--- a/src/main/java/com/susanghan_guys/server/personalwork/application/ReportInternalService.java
+++ b/src/main/java/com/susanghan_guys/server/personalwork/application/ReportInternalService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -50,6 +51,10 @@ public class ReportInternalService {
 
         runEvaluationInternal(workId);
         evaluationDone = true;
+
+        if (work.getCode() == null) {
+            work.updateCode(UUID.randomUUID().toString().substring(0, 6).toUpperCase());
+        }
 
         return ReportPipelineResponse.builder()
                 .summaryDone(summaryDone)

--- a/src/main/java/com/susanghan_guys/server/personalwork/application/ReportInternalService.java
+++ b/src/main/java/com/susanghan_guys/server/personalwork/application/ReportInternalService.java
@@ -8,6 +8,7 @@ import com.susanghan_guys.server.personalwork.exception.code.PersonalWorkErrorCo
 import com.susanghan_guys.server.personalwork.infrastructure.persistence.DetailEvalRepository;
 import com.susanghan_guys.server.personalwork.infrastructure.persistence.EvaluationRepository;
 import com.susanghan_guys.server.work.domain.Work;
+import com.susanghan_guys.server.work.domain.type.ReportStatus;
 import com.susanghan_guys.server.work.domain.type.WorkType;
 import com.susanghan_guys.server.work.exception.WorkException;
 import com.susanghan_guys.server.work.exception.code.WorkErrorCode;
@@ -30,7 +31,6 @@ public class ReportInternalService {
     private final YccWorkEvaluationService yccWorkEvaluationService;
     private final EvaluationRepository evaluationRepository;
     private final DetailEvalRepository detailEvalRepository;
-
 
     @Transactional
     public ReportPipelineResponse runPipeline(Long workId) {
@@ -55,6 +55,7 @@ public class ReportInternalService {
         if (work.getCode() == null) {
             work.updateCode(UUID.randomUUID().toString().substring(0, 6).toUpperCase());
         }
+        work.updateReportStatus(ReportStatus.COMPLETED);
 
         return ReportPipelineResponse.builder()
                 .summaryDone(summaryDone)

--- a/src/main/java/com/susanghan_guys/server/personalwork/application/YccWorkEvaluationService.java
+++ b/src/main/java/com/susanghan_guys/server/personalwork/application/YccWorkEvaluationService.java
@@ -17,7 +17,6 @@ import com.susanghan_guys.server.personalwork.infrastructure.persistence.DetailE
 import com.susanghan_guys.server.personalwork.infrastructure.persistence.EvaluationRepository;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.work.domain.Work;
-import com.susanghan_guys.server.work.domain.type.ReportStatus;
 import com.susanghan_guys.server.work.exception.WorkException;
 import com.susanghan_guys.server.work.exception.code.WorkErrorCode;
 import com.susanghan_guys.server.work.infrastructure.persistence.WorkRepository;
@@ -108,7 +107,6 @@ public class YccWorkEvaluationService {
             List<DetailEval> detailEvals = getOrCreateDetailEvaluation(workId, evaluation.getType());
             evaluation.updateScore(detailEvals);
         }
-        work.updateReportStatus(ReportStatus.COMPLETED);
 
         return evaluations;
     }

--- a/src/main/java/com/susanghan_guys/server/work/application/ReportService.java
+++ b/src/main/java/com/susanghan_guys/server/work/application/ReportService.java
@@ -1,5 +1,6 @@
 package com.susanghan_guys.server.work.application;
 
+import com.susanghan_guys.server.feedback.infrastructure.persistence.FeedbackRepository;
 import com.susanghan_guys.server.global.security.CurrentUserProvider;
 import com.susanghan_guys.server.user.domain.User;
 import com.susanghan_guys.server.work.application.validator.ReportValidator;
@@ -26,7 +27,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +35,7 @@ public class ReportService {
 
     private final CurrentUserProvider currentUserProvider;
     private final WorkRepository workRepository;
+    private final FeedbackRepository feedbackRepository;
     private final WorkVisibilityRepository workVisibilityRepository;
     private final ReportValidator reportValidator;
 
@@ -64,9 +65,11 @@ public class ReportService {
         Work work = workRepository.findById(workId)
                 .orElseThrow(() -> new WorkException(WorkErrorCode.WORK_NOT_FOUND));
 
+        boolean hasFeedback = feedbackRepository.existsByWorkAndUser(work, user);
+
         reportValidator.validateReportInfo(user, work);
 
-        return ReportInfoResponse.from(work);
+        return ReportInfoResponse.from(work, hasFeedback);
     }
 
     @Transactional

--- a/src/main/java/com/susanghan_guys/server/work/dto/response/ReportInfoResponse.java
+++ b/src/main/java/com/susanghan_guys/server/work/dto/response/ReportInfoResponse.java
@@ -20,9 +20,11 @@ public record ReportInfoResponse(
         Brand brand,
 
         @Schema(description = "공모전 팀원", example = "[\"김철수\", \"주정빈\", \"강수진\"]")
-        List<String> workMembers
+        List<String> workMembers,
+
+        boolean hasFeedback
 ) {
-    public static ReportInfoResponse from(Work work) {
+    public static ReportInfoResponse from(Work work, boolean hasFeedback) {
         return ReportInfoResponse.builder()
                 .workName(work.getTitle())
                 .contestName(work.getContest().getTitle())
@@ -32,6 +34,7 @@ public record ReportInfoResponse(
                                 .map(workMember -> workMember.getTeamMember().getName())
                                 .toList()
                 )
+                .hasFeedback(hasFeedback)
                 .build();
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- #131

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

> 리포트 정보 조회에 피드백 여부 포함
피드백 테이블 수정 (사용자와 연결)
메일 중복 발송 오류 수정

## 📸 스크린샷
<img width="835" height="359" alt="스크린샷 2025-09-02 163604" src="https://github.com/user-attachments/assets/e3433084-03a8-4e1f-aa84-b364dc4674bd" />

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 피드백 테이블 수정을 했는데 외래키 조건이 잘 걸리지 않아서 `feedback` 테이블만 drop 한 번 하고.. 다시 만들려고 하는데 만약 불안하거나 좋은 방법이 아닌 것 같다고 생각되시면 말씀해주세요
- 백엔드 내부 - 리포트 생성하는 로직 내부에 리포트 상태 바꾸는 로직이 없는 것 같아서 추가했습니다. 제가 발견 못한거면 알려주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 리포트 정보에 사용자의 피드백 여부(hasFeedback) 표시.
  - 동일 작품에 대해 사용자당 1회만 피드백 가능하도록 제한(중복 방지).
  - 평가 완료 후 코드가 없는 작품에 6자리 대문자 코드 자동 생성.
  - 일부 평가 흐름의 리포트 완료 처리 방식이 변경됨.

- 버그 수정
  - 작품 소유자에게 중복 알림 메일이 전송되지 않도록 제외 처리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->