### PR TITLE
feat: 메일 링크 수정

### DIFF
--- a/src/main/java/com/susanghan_guys/server/mail/application/MailService.java
+++ b/src/main/java/com/susanghan_guys/server/mail/application/MailService.java
@@ -58,24 +58,12 @@ public class MailService {
     }
 
     private void sendWorkMembers(Work work, String template) {
-        personalizeMail(new MailRequest(
-                work.getUser().getEmail(),
-                work.getUser().getName(),
-                work.getTitle(),
-                generateUserLink(work),
-                work.getCode(),
-                "[%s] 수상 리포트 완성 안내".formatted(work.getTitle())
-        ), template);
-
         for (WorkMember workMember : work.getWorkMembers()) {
-            if (work.getUser().getEmail().equals(workMember.getTeamMember().getEmail())) {
-                continue;
-            }
-            personalizeMail(new MailRequest(
+            personalizeMail(MailRequest.of(
                     workMember.getTeamMember().getEmail(),
                     workMember.getTeamMember().getName(),
                     work.getTitle(),
-                    generateWorkMemberLink(work),
+                    generateLink(work),
                     work.getCode(),
                     "[%s] 수상 리포트 완성 안내".formatted(work.getTitle())
             ), template);
@@ -104,12 +92,8 @@ public class MailService {
         }
     }
 
-    private String generateUserLink(Work work) {
+    private String generateLink(Work work) {
         return redirectUri + work.getId();
-    }
-
-    private String generateWorkMemberLink(Work work) {
-        return redirectUri + work.getId() + "/verify-code";
     }
 
     private String generateCode() {

--- a/src/main/java/com/susanghan_guys/server/mail/application/MailService.java
+++ b/src/main/java/com/susanghan_guys/server/mail/application/MailService.java
@@ -58,7 +58,19 @@ public class MailService {
     }
 
     private void sendWorkMembers(Work work, String template) {
+        personalizeMail(MailRequest.of(
+                work.getUser().getEmail(),
+                work.getUser().getName(),
+                work.getTitle(),
+                generateLink(work),
+                work.getCode(),
+                "[%s] 수상 리포트 완성 안내".formatted(work.getTitle())
+        ), template);
+
         for (WorkMember workMember : work.getWorkMembers()) {
+            if (work.getUser().getEmail().equals(workMember.getTeamMember().getEmail())) {
+                continue;
+            }
             personalizeMail(MailRequest.of(
                     workMember.getTeamMember().getEmail(),
                     workMember.getTeamMember().getName(),

--- a/src/main/java/com/susanghan_guys/server/mail/dto/request/MailRequest.java
+++ b/src/main/java/com/susanghan_guys/server/mail/dto/request/MailRequest.java
@@ -11,4 +11,14 @@ public record MailRequest(
         String code,
         String subject
 ) {
+    public static MailRequest of(String mail, String name, String title, String link, String code, String subject) {
+        return MailRequest.builder()
+                .mail(mail)
+                .name(name)
+                .title(title)
+                .link(link)
+                .code(code)
+                .subject(subject)
+                .build();
+    }
 }

--- a/src/main/java/com/susanghan_guys/server/work/dto/response/ReportInfoResponse.java
+++ b/src/main/java/com/susanghan_guys/server/work/dto/response/ReportInfoResponse.java
@@ -22,6 +22,7 @@ public record ReportInfoResponse(
         @Schema(description = "공모전 팀원", example = "[\"김철수\", \"주정빈\", \"강수진\"]")
         List<String> workMembers,
 
+        @Schema(description = "피드백 여부", example = "false")
         boolean hasFeedback
 ) {
     public static ReportInfoResponse from(Work work, boolean hasFeedback) {


### PR DESCRIPTION
## 🔗 연관된 이슈

- #136 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 신청자, 팀원에게 제공되는 리포트 링크 동일하게 수정

## 📸 스크린샷
<img width="772" height="432" alt="image" src="https://github.com/user-attachments/assets/6bc9d7b2-c92a-4f5a-bff6-90c51413632a" />
-> 신청자, 팀원 모두에게 동일한 리포트 링크로 전송되는 것 확인

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 리다이렉트 되는 건 백에서 403 에러 던져주면 프론트가 리포트 링크 쪽으로 리다이렉트 시켜줄 것 같습니다.
- 이거 하고 레디스 비번 설정하겠습니다..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 이메일 발송 로직을 정리하여 메일 요청 생성 방식을 일관화.
  - 모든 수신자에게 동일한 링크 형식을 사용하도록 통합하여, 메일 내 작업 링크가 redirect URI + 작업 ID 조합의 단일 형식으로 일관되게 동작.

- Documentation
  - API 문서에 ReportInfoResponse의 hasFeedback 필드 설명과 예시 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->