### PR TITLE
refactor: dca 점수 규칙 강화, 강점/보완점 쏠림 현상 해결

### DIFF
--- a/src/main/java/com/susanghan_guys/server/global/client/openai/prompt/DcaBriefEvaluationPrompt.java
+++ b/src/main/java/com/susanghan_guys/server/global/client/openai/prompt/DcaBriefEvaluationPrompt.java
@@ -7,8 +7,8 @@ public class DcaBriefEvaluationPrompt {
     public static OpenAiPrompt buildDcaBriefEvaluationPrompt(DcaOpenAiRequest.BrandBriefPayload brief) {
         String system = """
                 You are a professional assistant that analyzes a competition entry into three fields:
-                interpretation, consistency, weakness. Respond ONLY in Korean and return JSON with
-                keys: interpretation, consistency, weakness.
+                interpretation, consistency. Respond ONLY in Korean and return JSON with
+                keys: interpretation, consistency.
                 
                 Global rules
                 - Always output all three fields.
@@ -34,24 +34,6 @@ public class DcaBriefEvaluationPrompt {
                 - Evaluate alignment between the interpreted brief and execution (planning intent ↔ media/message/engagement design).
                 - Include at least one concrete example referencing story flow, media characteristics, or participation design.
                 - Focus on how consistently the brief’s core direction is carried through—not on micro design polish.
-                
-                3) weakness
-                - Exactly 1–2 sentences.\s
-                - Write in a short, critical, and declarative style (e.g., "~이 부족하다", "~이 약하다", "~이 드러나지 않는다").
-                - Always ground the weakness in a specific element of the submission (e.g., medium used, participation path, message framing).
-                - Focus only on major misalignments with the brief’s core requirements or weak linkage to the brand’s essential value.
-                - Do NOT include trivial design issues, technical usability, or time/place limitations.
-                - Avoid phrasing like "~할 수 있다", "~기 때문이다"; always state issues directly and decisively.
-                - If the work is overall strong, still provide one subtle risk framed in the same short, critical style.
-                
-                    # Good Weakness (use this style)
-                    - "캐릭터 아이프렌즈로 귀여움과 친근함은 살렸으나, 브랜드와 직접적 연계가 약해 장기적 팬덤 구축까지는 한계가 있음."
-                    - "버스 창문이 닫힐 때 전달되는 ‘채워짐’의 순간은 시각적으로 임팩트 있지만, 창문이 열리면 메시지가 단절되어 브랜드 기억 지속성이 약할 수 있다."
-                
-                    # Bad Weakness (do NOT write like this)
-                    - "더 창의적이어야 한다."        # ambiguous
-                    - "앱 사용성이 떨어질 수 있다."   # minor/Design Points
-                    - "문제가 없다고 본다."         # uncritical
                 """;
 
         String briefBlock = (brief == null) ? "" : """
@@ -71,7 +53,6 @@ public class DcaBriefEvaluationPrompt {
                 Analyze the following submission and output a JSON object with:
                 - "interpretation": exactly 2 sentences ([brief core] → [how reflected in campaign]).
                 - "consistency": 3–4 sentences with concrete examples of alignment.
-                - "weakness": **at least 1 sentence** (prefer 2), each naming a concrete element and its impact on brief/brand alignment; avoid design-only or time/place-specific remarks.
                 """.formatted(briefBlock);
 
         return new OpenAiPrompt(system, user);

--- a/src/main/java/com/susanghan_guys/server/global/client/openai/prompt/DcaWorkEvaluationPrompt.java
+++ b/src/main/java/com/susanghan_guys/server/global/client/openai/prompt/DcaWorkEvaluationPrompt.java
@@ -106,6 +106,10 @@ public class DcaWorkEvaluationPrompt {
                   If you assign ≤5, you must justify with one clear weakness/risk factor (do not list more than one).
                 - Below 5: Not allowed.
                 
+                Rationale rule:
+                - If score == 6 → add exactly one short weakness.
+                - If score ≥ 7 → no weaknesses, no “그러나/하지만/다만” style contrast.
+                
                 Conservativeness:
                 - Do NOT inflate scores without clear evidence.
                 - Be conservative: most scores should be 8 or below.

--- a/src/main/java/com/susanghan_guys/server/personalwork/domain/BriefAnalysis.java
+++ b/src/main/java/com/susanghan_guys/server/personalwork/domain/BriefAnalysis.java
@@ -24,9 +24,6 @@ public class BriefAnalysis extends BaseEntity {
     @Column(name = "consistency", nullable = false, length = 300)
     private String consistency;
 
-    @Column(name = "weakness", nullable = false, length = 300)
-    private String weakness;
-
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "work_id", nullable = false, unique = true)
     private Work work;
@@ -35,12 +32,10 @@ public class BriefAnalysis extends BaseEntity {
     public BriefAnalysis(
             String interpretation,
             String consistency,
-            String weakness,
             Work work
     ) {
         this.interpretation = interpretation;
         this.consistency = consistency;
-        this.weakness = weakness;
         this.work = work;
     }
 }

--- a/src/main/java/com/susanghan_guys/server/personalwork/dto/response/DcaBriefEvaluationResponse.java
+++ b/src/main/java/com/susanghan_guys/server/personalwork/dto/response/DcaBriefEvaluationResponse.java
@@ -17,12 +17,6 @@ public record DcaBriefEvaluationResponse(
                 description = "반영 일관성",
                 example = "캠페인은 타이머와 빼빼로를 결합하여 '잠시 톡! 끊어가도 괜찮아'라는 메시지를 통해 영타겟에게 휴식의 중요성을 전달하고 있다. 이는 브랜드의 본질적 가치인 '나눔/연결의 가치'를 유지하면서도 새로운 경험을 제공하려는 시도이다. 또한, 패키지 디자인과 메시지 전달 방식이 젊은 층의 일상과 잘 맞아떨어져 자발적 참여를 유도하고 있다. 이러한 요소들은 브랜드의 감성적 연결을 강화하는 데 일조하고 있다."
         )
-        String consistency,
-
-        @Schema(
-                description = "보완점",
-                example = "타이머와의 결합이 신선하지만, 빼빼로 자체의 매력보다는 부가적인 요소에 의존하는 경향이 있어 브랜드의 본질적 가치와의 직접적 연계가 약할 수 있다."
-        )
-        String weakness
+        String consistency
 ) {
 }

--- a/src/main/java/com/susanghan_guys/server/personalwork/infrastructure/mapper/BriefAnalysisMapper.java
+++ b/src/main/java/com/susanghan_guys/server/personalwork/infrastructure/mapper/BriefAnalysisMapper.java
@@ -12,7 +12,6 @@ public class BriefAnalysisMapper {
         return BriefAnalysis.builder()
                 .interpretation(resp.interpretation())
                 .consistency(safeTrim(resp.consistency(), MAX_LEN))
-                .weakness(safeTrim(resp.weakness(), MAX_LEN))
                 .work(work)
                 .build();
     }
@@ -21,7 +20,6 @@ public class BriefAnalysisMapper {
         return DcaBriefEvaluationResponse.builder()
                 .interpretation(e.getInterpretation())
                 .consistency(safeTrim(e.getConsistency(), MAX_LEN))
-                .weakness(safeTrim(e.getWeakness(), MAX_LEN))
                 .build();
     }
 


### PR DESCRIPTION
## 🔗 연관된 이슈

- #138

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 강점/보완점 조회 로직에 분산 규칙 적용
    - 강점 조회 시 동일 evaluation에 3개가 전부 몰리면 마지막 하나는 evaluation이 다른 최우선후보로 교체
    - 보완점 조회 시 evaluation 몰림 시 교체 시도, 교체 후보 없으면 보완점은 2개까지만 반환
- 브리프 해석에서 보완점 필드 삭제
- dca 점수 규칙 강화

## 📸 스크린샷


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 브리프 해석에서 보완점 필드를 삭제했기 때문에 운영용, 개발용에 병합 시 weakness 컬럼 드랍해야 합니다..!!!!..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 간단 평가 결과에서 ‘약점’ 항목을 제거하고 ‘해석’과 ‘일관성’ 두 항목만 제공하도록 변경했습니다.
  - 강점/약점 선정 로직을 개선해 상위 3개가 동일 평가에서만 나오지 않도록 다양성을 보장하고, 점수 경계 규칙을 적용했습니다.
  - AI 평가 프롬프트를 조정해 점수에 따른 근거 표기 규칙을 명확화했습니다.

- Bug Fixes
  - 상위/하위 결과가 특정 평가에 편중되어 표시되던 문제를 완화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->