### PR TITLE
fix: 리포트 신청자가 아닌 경우, 리포트 조회 불가능 에러 

### DIFF
--- a/src/main/java/com/susanghan_guys/server/personalwork/application/WorkSummaryService.java
+++ b/src/main/java/com/susanghan_guys/server/personalwork/application/WorkSummaryService.java
@@ -55,9 +55,7 @@ public class WorkSummaryService {
 
     @Transactional(readOnly = true)
     public WorkSummaryResponse getWorkSummary(Long workId) {
-        personalWorkValidator.validatePersonalWorkOwner(
-                workId, currentUserProvider.getCurrentUser()
-        );
+        personalWorkValidator.validatePersonalWorkAccessible(workId, currentUserProvider.getCurrentUser());
 
         Summary summary = summaryRepository.findByWorkId(workId)
                 .orElseThrow(() -> new PersonalWorkException(PersonalWorkErrorCode.SUMMARY_NOT_FOUND));


### PR DESCRIPTION
## 🔗 연관된 이슈

- #141

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 작품 요약도 조회 가능하게 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 권한 검증을 접근 가능 사용자 기준으로 정정하여, 소유자뿐 아니라 공유된 사용자도 개인 작업 요약을 조회할 수 있습니다.
  - 권한이 있음에도 조회가 불가하던 사례를 해소해 불필요한 접근 거부 오류를 줄였습니다. 프로젝트·팀 공유 시에도 동일하게 적용됩니다.
  - 요약이 없는 경우의 오류 메시지와 상태 코드는 그대로 유지되어 화면이나 사용 흐름의 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->