### PR TITLE
feat: 리포트 공유 url 수정

### DIFF
--- a/src/main/java/com/susanghan_guys/server/work/dto/response/ReportSharingResponse.java
+++ b/src/main/java/com/susanghan_guys/server/work/dto/response/ReportSharingResponse.java
@@ -10,7 +10,7 @@ public record ReportSharingResponse(
         @Schema(description = "작품 ID", defaultValue = "1")
         Long workId,
 
-        @Schema(description = "리포트 링크", defaultValue = "https://www.soosanghan.site/reports/22/verify-code")
+        @Schema(description = "리포트 링크", defaultValue = "https://www.soosanghan.site/reports/22")
         String link,
 
         @Schema(description = "리포트 코드", defaultValue = "64E8E8")
@@ -19,7 +19,7 @@ public record ReportSharingResponse(
     public static ReportSharingResponse from(Work work) {
         return ReportSharingResponse.builder()
                 .workId(work.getId())
-                .link("https://www.soosanghan.site/reports/" + work.getId() + "/verify-code")
+                .link("https://www.soosanghan.site/reports/" + work.getId())
                 .code(work.getCode())
                 .build();
     }


### PR DESCRIPTION
## 🔗 연관된 이슈

- #149 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 리포트 공유 url 수정

## 📸 스크린샷
<img width="611" height="428" alt="image" src="https://github.com/user-attachments/assets/7c41a26c-ca3e-431c-9314-208be0f6585a" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 리포트 공유 링크가 /reports/{id}/verify-code 대신 /reports/{id}로 연결되도록 수정했습니다. 이제 링크를 열면 검증 단계 없이 바로 리포트 화면으로 이동합니다. 기본 표시 예시도 동일하게 갱신되어 새로 생성되는 공유 응답에 올바른 링크가 제공됩니다. 이로써 공유 링크 접근 흐름이 단순해지고 불필요한 단계로 인한 혼란이 줄어듭니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->