### PR TITLE
fix: 리포트 리디렉션 수정

### DIFF
--- a/src/main/java/com/susanghan_guys/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/susanghan_guys/server/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.susanghan_guys.server.global.config;
 
+import com.susanghan_guys.server.global.filter.RedirectUriFilter;
 import com.susanghan_guys.server.global.security.handler.JwtAccessDeniedHandler;
 import com.susanghan_guys.server.global.security.handler.JwtAuthenticationEntryPoint;
 import com.susanghan_guys.server.global.security.jwt.JwtAuthenticationFilter;
@@ -13,6 +14,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -26,6 +28,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final RedirectUriFilter redirectUriFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -59,6 +62,7 @@ public class SecurityConfig {
                                 .userService(customOAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)
                 )
+                .addFilterBefore(redirectUriFilter, OAuth2AuthorizationRequestRedirectFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/susanghan_guys/server/global/filter/RedirectUriFilter.java
+++ b/src/main/java/com/susanghan_guys/server/global/filter/RedirectUriFilter.java
@@ -1,0 +1,42 @@
+package com.susanghan_guys.server.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class RedirectUriFilter extends OncePerRequestFilter {
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !request.getRequestURI().startsWith("/oauth2/authorization");
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String redirectUri = request.getParameter("redirect");
+
+        if (redirectUri != null && !redirectUri.isBlank()) {
+            Cookie cookie = new Cookie("redirect", URLEncoder.encode(redirectUri, StandardCharsets.UTF_8));
+
+            cookie.setHttpOnly(true);
+            cookie.setPath("/");
+            cookie.setMaxAge(60);
+            response.addCookie(cookie);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/susanghan_guys/server/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/susanghan_guys/server/oauth2/handler/OAuth2SuccessHandler.java
@@ -7,6 +7,7 @@ import com.susanghan_guys.server.oauth2.infrastructure.persistence.RefreshTokenR
 import com.susanghan_guys.server.global.security.CustomUserDetails;
 import com.susanghan_guys.server.global.util.RedisUtil;
 import com.susanghan_guys.server.user.domain.User;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
@@ -33,9 +38,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     @Value("${frontend.oauth2.base-redirect-uri}")
     private String baseRedirectUri;
-
-    @Value("${frontend.oauth2.report-redirect-uri}")
-    private String reportRedirectUri;
 
     @Override
     public void onAuthenticationSuccess(
@@ -65,24 +67,19 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                         "isSignUp", String.valueOf(isSignUp)
                 )), 1000 * 60L);
 
-        String requestParam = request.getParameter("state");
+        String redirectPath = Arrays.stream(Optional.ofNullable(request.getCookies()).orElse(new Cookie[0]))
+                .filter(c -> "redirect".equals(c.getName()))
+                .findFirst()
+                .map(c -> URLDecoder.decode(c.getValue(), StandardCharsets.UTF_8))
+                .orElse("/oauth/callback");
 
-        String redirectUri;
-        if (requestParam != null && requestParam.startsWith("/reports")) {
-            redirectUri = reportRedirectUri + requestParam;
-        } else {
-            redirectUri = baseRedirectUri;
-        }
+        String targetUri = baseRedirectUri + redirectPath;
 
         String callbackUri = UriComponentsBuilder
-                .fromUriString(redirectUri)
+                .fromUriString(targetUri)
                 .queryParam("code", tempCode)
-                .build(true)
+                .build()
                 .toUriString();
-
-        log.info("requestParam = {}", requestParam);
-        log.info("redirectUri = {}", redirectUri);
-        log.info("callbackUri = {}", callbackUri);
 
         response.sendRedirect(callbackUri);
     }


### PR DESCRIPTION
## 🔗 연관된 이슈

- #155 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 프론트 요청에 따라 로그인 후, 리디렉션 수정

## 📸 스크린샷
> `redirect` 파라미터가 존재할 경우, 리포트 코드 인증 모달로 이동
<img width="930" height="351" alt="image" src="https://github.com/user-attachments/assets/c141c773-3c39-485c-b621-bd7e85915c53" />

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- yml 바뀌엇습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - OAuth 로그인 후 사용자 지정 경로로 안전하게 리디렉션됩니다. 로그인 시작 시 제공한 redirect 값이 짧은 기간(60초) 유지되는 HttpOnly 쿠키에 저장되어, 인증 성공 시 해당 경로로 이동합니다.
  - 리디렉션 경로가 제공되지 않은 경우, 기본 콜백 경로로 이동해 일관된 로그인 흐름을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->